### PR TITLE
12 data transmission and database

### DIFF
--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -63,7 +63,6 @@ class Dashboard:
                 "currentAngle": float(raw_data.get("IREG_2_200", 0)),
                 "consumption": 0,  # Placeholder
                 "currentEmissions": 0,  # Placeholder
-                "ecoScore": 0,  # Placeholder
             }
             return formatted_data
         except Exception as e:

--- a/backend/persistance/database.py
+++ b/backend/persistance/database.py
@@ -1,40 +1,52 @@
 # Database connection and query handling - This is where the runs are stored and retrieved from the database
 import sqlite3
 
+import sqlite3
+import asyncio
+
 class Database:
     def __init__(self, db_name="runs.db"):
-        self.connection = sqlite3.connect(db_name)
-        self.cursor = self.connection.cursor()
-        self.create_table()
+        self.db_name = db_name
+        self._ensure_table_exists()
 
-    def create_table(self):
-        """Create the Run table if it doesn't already exist."""
-        self.cursor.execute('''
-            CREATE TABLE IF NOT EXISTS Run (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                eco_score REAL NOT NULL,
-                total_emissions REAL NOT NULL,
-                run_time REAL NOT NULL,
-                configuration_number INTEGER NOT NULL
-            )
-        ''')
-        self.connection.commit()
+    def _ensure_table_exists(self):
+        """Ensure the table exists before inserting data."""
+        with sqlite3.connect(self.db_name) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS Run (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_time REAL NOT NULL,
+                    total_consumption REAL NOT NULL,
+                    configuration_number INTEGER NOT NULL,
+                    average_speed REAL NOT NULL,
+                    average_rpm REAL NOT NULL
+                )
+            ''')
+            conn.commit()
 
-    def store_data(self, eco_score, total_emissions, run_time, configuration_number):
-        """Insert a new record into the Run table."""
-        self.cursor.execute('''
-            INSERT INTO Run (eco_score, total_emissions, run_time, configuration_number)
-            VALUES (?, ?, ?, ?)
-        ''', (eco_score, total_emissions, run_time, configuration_number))
-        self.connection.commit()
-    
-    # Remove all data from database
+    async def store_data(self, run_time, total_consumption, configuration_number, average_speed, average_rpm):
+        """Store run data asynchronously."""
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._store_data_sync, run_time, total_consumption, configuration_number, average_speed, average_rpm)
+
+    def _store_data_sync(self, run_time, total_consumption, configuration_number, average_speed, average_rpm):
+        """Insert a new record into the database (blocking function)."""
+        with sqlite3.connect(self.db_name) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                INSERT INTO Run (run_time, total_consumption, configuration_number, average_speed, average_rpm)
+                VALUES (?, ?, ?, ?, ?)
+            ''', (run_time, total_consumption, configuration_number, average_speed, average_rpm))
+            conn.commit()
+
     def clear_data(self):
-        self.cursor.execute('''
-            DELETE FROM Run
-        ''')
-        self.connection.commit()
+        """Remove all data from database."""
+        with sqlite3.connect(self.db_name) as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM Run")
+            conn.commit()
 
     def close(self):
         """Close the database connection."""
-        self.connection.close()
+        pass  # No need for explicit closing when using `with sqlite3.connect`

--- a/dashboard/src/hooks/useSimulatorWebSocket.tsx
+++ b/dashboard/src/hooks/useSimulatorWebSocket.tsx
@@ -7,6 +7,7 @@ export function UseSimulatorWebSocket(
 ) {
   const [data, setData] = useState<SimulatorData>(initialSimData)
   const ws = useRef<WebSocket | null>(null)
+  const [isConnected, setIsConnected] = useState<boolean>(false)
 
   useEffect(() => {
     if (ws.current) {
@@ -15,23 +16,41 @@ export function UseSimulatorWebSocket(
 
     ws.current = new WebSocket(url)
 
+    ws.current.onopen = () => {
+      setIsConnected(true)
+      console.log('Simulator WebSocket connected')
+    }
+
     ws.current.onmessage = (event) => {
       try {
         const message: SimulatorData = JSON.parse(
           event.data as string
         ) as SimulatorData
-
         setData(message)
       } catch (error) {
-        console.error('Error parsing WebSocket message', error)
+        console.error('Error parsing WebSocket message from simulator', error)
       }
     }
 
-    ws.current.onerror = (error) => console.error('WebSocket error', error)
-    ws.current.onclose = () => console.log('WebSocket connection closed')
+    ws.current.onerror = (error) =>
+      console.error('Simulator WebSocket error', error)
+
+    ws.current.onclose = () => {
+      setIsConnected(false)
+      console.log('Simulator WebSocket connection closed')
+    }
 
     return () => ws.current?.close()
-  }, [url])
+  }, [url]) // WebSocket should reconnect when simulation state changes
 
-  return { data }
+  // Function to send messages to the simulator WebSocket
+  const sendMessage = (message: string) => {
+    if (ws.current && ws.current.readyState === WebSocket.OPEN) {
+      ws.current.send(message)
+    } else {
+      console.warn('Simulator WebSocket is not connected')
+    }
+  }
+
+  return { data, isConnected, sendMessage }
 }

--- a/dashboard/src/hooks/useWebSocket.tsx
+++ b/dashboard/src/hooks/useWebSocket.tsx
@@ -60,8 +60,7 @@ export function UseWebSocket(url: string, initialData: DashboardData) {
       'currentThrust' in data &&
       'currentAngle' in data &&
       'consumption' in data &&
-      'currentEmissions' in data &&
-      'ecoScore' in data
+      'currentEmissions' in data
     )
   }
 
@@ -73,8 +72,7 @@ export function UseWebSocket(url: string, initialData: DashboardData) {
       newData.currentThrust !== oldData.currentThrust ||
       newData.currentAngle !== oldData.currentAngle ||
       newData.consumption !== oldData.consumption ||
-      newData.currentEmissions !== oldData.currentEmissions ||
-      newData.ecoScore !== oldData.ecoScore
+      newData.currentEmissions !== oldData.currentEmissions
     )
   }
 

--- a/dashboard/src/hooks/useWebSocket.tsx
+++ b/dashboard/src/hooks/useWebSocket.tsx
@@ -51,6 +51,15 @@ export function UseWebSocket(url: string, initialData: DashboardData) {
     }
   }, [url]) // ✅ Depend only on `url` to avoid re-creating unnecessary WebSockets
 
+  // To be able to send messages to the backend
+  const sendMessage = (message: string) => {
+    if (ws.current && ws.current.readyState === WebSocket.OPEN) {
+      ws.current.send(message)
+    } else {
+      console.warn('WebSocket is not open')
+    }
+  }
+
   function isDashboardData(
     data: DashboardData | string
   ): data is DashboardData {
@@ -70,11 +79,9 @@ export function UseWebSocket(url: string, initialData: DashboardData) {
   ): boolean {
     return (
       newData.currentThrust !== oldData.currentThrust ||
-      newData.currentAngle !== oldData.currentAngle ||
-      newData.consumption !== oldData.consumption ||
-      newData.currentEmissions !== oldData.currentEmissions
+      newData.currentAngle !== oldData.currentAngle
     )
   }
 
-  return { data, isConnected }
+  return { data, isConnected, sendMessage }
 }

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -3,18 +3,24 @@ import { Compass } from '../components/Compass'
 import { InstrumentField } from '../components/InstrumentField'
 import { UseWebSocket } from '../hooks/useWebSocket'
 import { UseSimulatorWebSocket } from '../hooks/useSimulatorWebSocket'
-import { memo, useEffect } from 'react'
+import { memo, useEffect, useState } from 'react'
 import '../styles/dashboard.css'
 import '../styles/instruments.css'
 import { DashboardData, SimulatorData } from '../types/DashboardData'
-import { toHeading, gramsToKiloGrams } from '../utils/Convertion'
+import {
+  toHeading,
+  gramsToKiloGrams,
+  calculateAverage
+} from '../utils/Convertion'
 
 export function Dashboard() {
+  const [simulationRunning, setSimulationRunning] = useState<boolean>(false)
+  const [speedData, setSpeedData] = useState<number[]>([])
+  const [rpmData, setRpmData] = useState<number[]>([])
+
   const initialData: DashboardData = {
     currentThrust: 20,
-    currentAngle: 80, // Between -90 and 90
-    consumption: 0,
-    currentEmissions: 20
+    currentAngle: 80 // Between -90 and 90
   }
 
   const initialSimData: SimulatorData = {
@@ -31,35 +37,117 @@ export function Dashboard() {
     angle: 0 // Angle of azimuth thruster
   }
 
-  const data = UseWebSocket('ws://127.0.0.1:8000/ws', initialData)
-  const simulatorData = UseSimulatorWebSocket(
-    'ws://127.0.0.1:8003',
-    initialSimData
+  const { sendMessage: sendToSimulator, data: simulatorData } =
+    UseSimulatorWebSocket('ws://127.0.0.1:8003', initialSimData)
+  const { sendMessage: sendToBackend, data } = UseWebSocket(
+    'ws://127.0.0.1:8000/ws',
+    initialData
   )
+
   // Store WebSocket data globally
   useEffect(() => {
-    window.azimuthControllerData = data.data // Global variable for simulator
+    window.azimuthControllerData = data // Global variable for simulator
   }, [data])
+
+  // Store speed and RPM when data arrives
+  useEffect(() => {
+    if (simulatorData) {
+      setSpeedData((prev) => [...prev, simulatorData.speed])
+      setRpmData((prev) => [...prev, simulatorData.rpm])
+    }
+  }, [simulatorData])
+
+  const startSimulation = () => {
+    // Change key to force iframe reload
+    sendToSimulator(JSON.stringify({ command: 'start_simulation' }))
+
+    console.log('Start simulation command sent')
+    setSimulationRunning(true)
+
+    // Reload the iframe when simulation starts
+    const iframe = document.querySelector(
+      '.simulator-panel iframe'
+    ) as HTMLIFrameElement
+    if (iframe) {
+      setTimeout(() => {
+        // eslint-disable-next-line no-self-assign
+        iframe.src = iframe.src
+      }, 1000) // Wait 1 second to allow the server to start
+    }
+  }
+
+  const stopSimulation = () => {
+    // Send stop signal to simulator (8003)
+    sendToSimulator(JSON.stringify({ command: 'stop_simulation' }))
+
+    // Set simulation as stopped
+    setSimulationRunning(false)
+
+    // Calculate Averages
+    const avgSpeed = calculateAverage(speedData)
+    const avgRpm = calculateAverage(rpmData)
+
+    // Assume emissions and runtime are stored or calculated in frontend
+    const totalConsumption = simulatorData.consumedTotal
+    const runTime = 100 //TODO this can be calculated from the start and stop time of the simulation
+    const configurationNumber = 1 // TODO Hardcoded for now, this will be selected from dropdown (issue 34)
+
+    console.log(`Avg Speed: ${avgSpeed}, Avg RPM: ${avgRpm}`)
+
+    // Send data to backend for storage
+    sendToBackend(
+      JSON.stringify({
+        command: 'stop_simulation',
+        avg_speed: avgSpeed,
+        avg_rpm: avgRpm,
+        total_consumption: totalConsumption,
+        run_time: runTime,
+        configuration_number: configurationNumber
+      })
+    )
+
+    // Clear local storage for next run
+    setSpeedData([])
+    setRpmData([])
+  }
 
   return (
     <div className="dashboard">
       {/* Simulator Panel */}
-      <div className="simulator-panel">
-        <iframe src="http://127.0.0.1:8002/index.html" />
-      </div>
+      {simulationRunning && (
+        <div className="simulator-panel">
+          <iframe src="http://127.0.0.1:8002/index.html" />
+        </div>
+      )}
       <div className="ui-panel">
+        <div className="button-row">
+          <button
+            onClick={startSimulation}
+            className="button"
+            disabled={simulationRunning}
+          >
+            Start Simulation
+          </button>
+          <button
+            onClick={stopSimulation}
+            className="button"
+            disabled={!simulationRunning}
+          >
+            Stop Simulation
+          </button>
+        </div>
         <h3>Propulsion</h3>
         <div className="intrument-panel-col">
           <div className="instrument-panel-row">
             <InstrumentField
-              value={data.data.currentThrust}
+              value={data.currentThrust}
               tag="Power"
               unit="%"
               source="Azimuth"
               hasSource={true}
             ></InstrumentField>
             <InstrumentField
-              value={data.data.currentAngle}
+              value={data.currentAngle}
               degree={true}
               tag="Angle"
               unit="°"
@@ -67,13 +155,13 @@ export function Dashboard() {
               hasSource={true}
             ></InstrumentField>
             <InstrumentField
-              value={simulatorData.data.rpm}
+              value={simulatorData.rpm}
               tag="RPM"
               source="Simulator"
               hasSource={true}
             ></InstrumentField>
             <InstrumentField
-              value={simulatorData.data.speed}
+              value={simulatorData.speed}
               tag="Speed"
               unit="kn"
               source="Simulator"
@@ -82,8 +170,8 @@ export function Dashboard() {
           </div>
           <div className="instrument-panel-row">
             <MemoizedAzimuthThruster
-              thrust={data.data.currentThrust}
-              angle={data.data.currentAngle}
+              thrust={data.currentThrust}
+              angle={data.currentAngle}
               setPoint={10}
               touching={true}
               atThrustSetpoint={false}
@@ -98,7 +186,7 @@ export function Dashboard() {
             <InstrumentField
               setPoint={0}
               hasSetPoint={true}
-              value={toHeading(simulatorData.data.heading)}
+              value={toHeading(simulatorData.heading)}
               degree={true}
               maxDigits={3}
               fractionDigits={0}
@@ -110,7 +198,7 @@ export function Dashboard() {
             <InstrumentField
               setPoint={0}
               hasSetPoint={true}
-              value={simulatorData.data.xPos}
+              value={simulatorData.xPos}
               degree={false}
               maxDigits={3}
               fractionDigits={1}
@@ -122,7 +210,7 @@ export function Dashboard() {
             <InstrumentField
               setPoint={0}
               hasSetPoint={true}
-              value={simulatorData.data.yPos}
+              value={simulatorData.yPos}
               degree={false}
               maxDigits={3}
               fractionDigits={1}
@@ -134,7 +222,7 @@ export function Dashboard() {
           </div>
           <div className="instrument-panel-row">
             <MemoizedCompass
-              heading={simulatorData.data.heading}
+              heading={simulatorData.heading}
               courseOverGround={90}
               headingAdvices={[]}
             />
@@ -146,7 +234,7 @@ export function Dashboard() {
           <h3>Eco Parameters</h3>
           <div className="instrument-panel-row">
             <InstrumentField
-              value={simulatorData.data.consumptionRate}
+              value={simulatorData.consumptionRate}
               tag="Cons"
               unit="kg/h"
               source="Simulator"
@@ -155,7 +243,7 @@ export function Dashboard() {
               fractionDigits={1}
             ></InstrumentField>
             <InstrumentField
-              value={gramsToKiloGrams(simulatorData.data.consumedTotal)}
+              value={gramsToKiloGrams(simulatorData.consumedTotal)}
               tag="ConsT"
               unit="kg"
               source="Simulator"
@@ -170,7 +258,7 @@ export function Dashboard() {
         {/* Checkpoints */}
         <div className="info-card">
           <h3>Checkpoints</h3>
-          <p>Remaining: {simulatorData.data.checkpoints} out of 3</p>
+          <p>Remaining: {simulatorData.checkpoints} out of 3</p>
         </div>
       </div>
     </div>

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -14,8 +14,7 @@ export function Dashboard() {
     currentThrust: 20,
     currentAngle: 80, // Between -90 and 90
     consumption: 0,
-    currentEmissions: 20,
-    ecoScore: 100
+    currentEmissions: 20
   }
 
   const initialSimData: SimulatorData = {

--- a/dashboard/src/pages/MiniDashboard.tsx
+++ b/dashboard/src/pages/MiniDashboard.tsx
@@ -14,7 +14,6 @@ export function MiniDashboard() {
     currentAngle: 80, // Between -90 and 90
     consumption: 0,
     currentEmissions: 20,
-    ecoScore: 100
   }
 
   const data = UseWebSocket('ws://127.0.0.1:8000/ws', initialData)

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -51,6 +51,44 @@
   min-width: 30%;
 }
 
+.button-row {
+  display: flex;
+  justify-content: center; /* Center the buttons */
+  gap: 15px; /* Add space between buttons */
+  margin-bottom: 15px; /* Add space below the buttons */
+}
+
+.button {
+  padding: 10px 20px;
+  font-size: 16px;
+  font-weight: bold;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.button:hover {
+  opacity: 0.8;
+}
+
+.button:active {
+  transform: scale(0.98);
+}
+
+/* Start Button */
+.button:first-child {
+  background-color: #4CAF50; /* Green */
+  color: white;
+}
+
+/* Stop Button */
+.button:last-child {
+  background-color: #d9534f; /* Red */
+  color: white;
+}
+
+
 /* Styling for the AzimuthThruster Component TODO: not in use 
 .azimuth-thruster-container {
     width: 90%;

--- a/dashboard/src/types/DashboardData.ts
+++ b/dashboard/src/types/DashboardData.ts
@@ -1,8 +1,6 @@
 export type DashboardData = {
   currentThrust: number
   currentAngle: number
-  consumption: number
-  currentEmissions: number
 }
 
 export type SimulatorData = {

--- a/dashboard/src/types/DashboardData.ts
+++ b/dashboard/src/types/DashboardData.ts
@@ -3,7 +3,6 @@ export type DashboardData = {
   currentAngle: number
   consumption: number
   currentEmissions: number
-  ecoScore: number
 }
 
 export type SimulatorData = {

--- a/dashboard/src/utils/Convertion.tsx
+++ b/dashboard/src/utils/Convertion.tsx
@@ -13,3 +13,10 @@ export function gramsToKiloGrams(grams: number) {
 export function toHeading(value: number): number {
   return (value + 360) % 360
 }
+
+// Calculate averages
+export function calculateAverage(arr: number[]) {
+  return arr.length
+    ? arr.reduce((sum, value) => sum + value, 0) / arr.length
+    : 0
+}

--- a/simulator/simulator_websocket_server.py
+++ b/simulator/simulator_websocket_server.py
@@ -1,9 +1,16 @@
-import logging
-from websocket_server import WebsocketServer
+import os
 import json
+import logging
+import subprocess
+from websocket_server import WebsocketServer
 
 # Store connected dashboard clients as a list (not a set)
 dashboard_clients = []
+simulation_running = False  # Global flag for stopping simulation
+simulation_process = None  # Global variable for the simulator process
+
+# Create WebSocket server
+server = WebsocketServer(host="localhost", port=8003, loglevel=logging.INFO)
 
 def new_client(client, server):
     """Handles a new dashboard client connection."""
@@ -13,11 +20,47 @@ def new_client(client, server):
 def client_left(client, server):
     """Handles a dashboard client disconnection."""
     print(f"Dashboard disconnected: {client['id']}")
-    if client in dashboard_clients:
-        dashboard_clients.remove(client)  # Use remove() instead of discard()
+    if client:  # Check if client is still connected
+        if client in dashboard_clients:
+            dashboard_clients.remove(client)  # Use remove() instead of discard()
 
 def message_received(client, server, message):
-    """Handles messages from the simulator and forwards them to dashboards."""
+    """Handles messages from both the simulator and the dashboard."""
+    global simulation_running #TODO is it okay to keep this global variable when i have simulation_process?
+    global simulation_process
+    try:
+        data = json.loads(message)
+        print(f"Received message: {data}")
+
+        # Check if this is a command from the dashboard
+        if "command" in data:
+            if data["command"] == "stop_simulation":
+                print("Simulation stopped by dashboard command.")
+                simulation_running = False  # Stop the simulation loop
+                # TODO Does this stop the simulation (index.html)?
+                if simulation_process:
+                    print("terminating simulation process")
+                    simulation_process.terminate()  # Kill the process
+                    simulation_process = None
+                return
+            if data["command"] == "start_simulation":
+                print("Simulation started by dashboard command.")
+                simulation_running = True  # Start simulation
+                if simulation_process is None:
+                    simulation_process = subprocess.Popen(["python", "-m", "http.server", "8002"])
+                return
+            
+        # If not a command, assume it's simulator data and forward it
+        if simulation_running:
+            for dashboard_client in dashboard_clients:
+                server.send_message(dashboard_client, json.dumps(data))
+
+
+    except Exception as e:
+        print(f"Error processing message: {e}")
+"""
+def message_received(client, server, message):
+    Handles messages from the simulator and forwards them to dashboards.
     try:
         data = json.loads(message)
         print(f"Received from simulator: {data}")
@@ -28,9 +71,8 @@ def message_received(client, server, message):
 
     except Exception as e:
         print(f"Error processing message: {e}")
+"""
 
-# Create WebSocket server
-server = WebsocketServer(host="localhost", port=8003, loglevel=logging.INFO)
 
 # Set up event handlers
 server.set_fn_new_client(new_client)


### PR DESCRIPTION
This PR removes the eco-score logic, as it is no longer necessary. The eco-score was an abstract layer over consumption, time, and speed variables that did not provide additional value. As a result, this PR updates the DashboardData type and modifies how data is stored after a simulation run. Additionally, it improves WebSocket communication between the frontend, backend, and simulator.

**Remove Eco-Score**
- Deleted eco-score from DashboardData type.
- Removed eco-score column from the database.
- Stopped sending eco-score data from the backend.

**Refactor Data Storage and WebSockets**
- Added new database columns for average speed and average RPM.**
- Made both frontend WebSockets read/write, enabling the backend to store simulation data, and the frontend to send shutdown signals to the simulator.
- Implemented "start_simulation" call from the frontend to the simulator.
- Swapped "save_averages" for "end_run" to better represent data handling.
- Stopped storing Consumption and CurrentEmissions in _formatted_data_ (backend) and _DashboardData_ (frontend), because this data is already provided by the simulator.
- Sent total emissions, run time, and configuration number from the frontend.
- Replaced total_emissions with total_consumption in database and WebSocket logic (dashboard.py).

**Simulator Integration Improvements**
- Worked on stopping the simulator through code.
- Investigating whether all position (thruster) and angle registers should be sent from the backend instead of just one (not sure about this one yet).