### PR TITLE
44 add a UI option to set the setpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,19 @@ npm start
 
 - Exposes functionality via REST API or WebSockets.
 
+## Running the application
+
+### Simulator
+
+cd simulator
+python simulator_websocket.py
+
+### Backend
+
+cd backend
+python main.py
+
+### Frontend
+
+cd dashboard
+npm run dev

--- a/backend/infrastructure/controller/azimuth_controller.py
+++ b/backend/infrastructure/controller/azimuth_controller.py
@@ -184,6 +184,39 @@ class AzimuthController:
                     
         return data_values
     
+    def set_setpoint(self, thrust_value: int, angle_value: int):
+        """
+        Writes the setpoint values to the Modbus registers.
+
+        :param thrust_value: The setpoint for thrust (-100% - 100%).
+        :param angle_value: The setpoint for azimuth angle (-180° to 180°).
+        """
+        if not self.client or not self.client.connected:
+            print("[ERROR] Not connected to Modbus. Cannot set setpoint.")
+            return False
+
+        try:
+            # HREG 04 is used to set the primary setpoint (thrust and angle)
+            thrust_register = 0x04
+            angle_register = 0x104  # Assuming this is the correct register for angle setpoint??
+
+            # Write thrust setpoint
+            self.client.write_register(address=thrust_register, value=int(thrust_value), slave=self.slave_id)
+            print(f"[INFO] Set thrust setpoint to {thrust_value}% at register {thrust_register}")
+
+            # Write angle setpoint
+            self.client.write_register(address=angle_register, value=int(angle_value), slave=self.slave_id)
+            print(f"[INFO] Set angle setpoint to {angle_value}° at register {angle_register}")
+
+            return True
+
+        except ModbusIOException as e:
+            print(f"[ERROR] Modbus IO Exception while writing setpoints: {e}")
+            return False
+        except Exception as e:
+            print(f"[ERROR] Unexpected error while writing setpoints: {e}")
+            return False
+    
 
     async def get_latest_data(self):
         """Provide the latest register data for external use."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,6 @@ import signal
 from fastapi import FastAPI
 import uvicorn
 from infrastructure.websocket.dashboard import router as ws_router, dashboard
-from infrastructure.controller.azimuth_controller import controller
 from persistance.database import Database
 from application.api import router as api_router
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,7 +21,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",
-    "react-tabs": "^6.1.0"
+    "react-tabs": "^6.1.0",
+    "react-use-websocket": "^4.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/dashboard/src/components/AzimuthThruster.tsx
+++ b/dashboard/src/components/AzimuthThruster.tsx
@@ -6,47 +6,53 @@ import '../styles/dashboard.css'
 type AzimuthThrusterProps = {
   thrust: number //  The thrust of the thruster in percent (0-100)
   angle: number // The angle of the propeller (?)
-  setPoint: number | undefined // The setpoint of the thruster in percent (0-100)
+  thrustSetPoint: number | undefined // Undefined means that there is no setpoint
+  angleSetpoint: number | undefined
   touching: boolean // Whether the thruster is being touched by the operator'
   atThrustSetpoint: boolean // Whether the thruster is at the setpoint
   atAngleSetpoint: boolean // Whether the angle is at the setpoint
+  onSetPointChange: (type: 'thrust' | 'angle', value: number) => void // Callback function
 }
 
 export function AzimuthThruster({
   thrust,
   angle,
-  setPoint,
+  thrustSetPoint = 0,
+  angleSetpoint = 0,
   touching,
   atThrustSetpoint,
-  atAngleSetpoint
+  atAngleSetpoint,
+  onSetPointChange
 }: AzimuthThrusterProps) {
-  {
-    /*
-  return (
-    <div className="dashboard-component">
-      <ObcAzimuthThrusterLabeled
-        thrust={thrust}
-        angle={angle}
-        thrustSetpoint={setPoint}
-        touching={touching}
-        atThrustSetpoint={atThrustSetpoint}
-        atAngleSetpoint={atAngleSetpoint}
-      ></ObcAzimuthThrusterLabeled>
-    </div>
-  )
-}
-  */
-  }
   return (
     <div className="dashboard-component">
       <ObcAzimuthThruster
         thrust={thrust}
         angle={angle}
-        thrustSetpoint={setPoint}
+        angleSetpoint={angleSetpoint}
+        thrustSetpoint={thrustSetPoint}
         touching={touching}
         atThrustSetpoint={atThrustSetpoint}
         atAngleSetpoint={atAngleSetpoint}
       ></ObcAzimuthThruster>
+      <div className="setpoint-controls">
+        <label>Thrust Setpoint</label>
+        <input
+          type="range"
+          min="-100"
+          max="100"
+          value={thrustSetPoint}
+          onChange={(e) => onSetPointChange('thrust', Number(e.target.value))}
+        />
+        <label>Angle Setpoint</label>
+        <input
+          type="range"
+          min="-180"
+          max="180"
+          value={angleSetpoint}
+          onChange={(e) => onSetPointChange('angle', Number(e.target.value))}
+        />
+      </div>
     </div>
   )
 }

--- a/dashboard/src/hooks/useSimulation.ts
+++ b/dashboard/src/hooks/useSimulation.ts
@@ -1,10 +1,10 @@
-import { useContext } from "react";
-import { SimulationContext } from "../context/SimulationContext";
+import { useContext } from 'react'
+import { SimulationContext } from '../context/SimulationContext'
 
 export function useSimulation() {
-    const context = useContext(SimulationContext);
-    if (!context) {
-      throw new Error("useSimulation must be used within a SimulationProvider");
-    }
-    return context;
+  const context = useContext(SimulationContext)
+  if (!context) {
+    throw new Error('useSimulation must be used within a SimulationProvider')
   }
+  return context
+}

--- a/dashboard/src/hooks/useWebSocket.tsx
+++ b/dashboard/src/hooks/useWebSocket.tsx
@@ -1,93 +1,38 @@
-import { useEffect, useState, useRef } from 'react'
+import useWebSocket, { ReadyState } from 'react-use-websocket'
+import { useEffect, useState } from 'react'
 import { DashboardData } from '../types/DashboardData'
 
 export function UseWebSocket(url: string, initialData: DashboardData) {
   const [data, setData] = useState<DashboardData>(initialData)
-  const ws = useRef<WebSocket | null>(null)
-  const latestData = useRef<DashboardData>(initialData)
-  const [isConnected, setIsConnected] = useState<boolean>(false)
 
+  const { sendJsonMessage, lastJsonMessage, readyState } = useWebSocket(url, {
+    onOpen: () => console.log('WebSocket connected'),
+    onClose: () => console.log('WebSocket disconnected'),
+    onError: (error) => console.error('WebSocket Error:', error),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    shouldReconnect: (closeEvent) => true, // Auto-reconnect if disconnected
+    reconnectAttempts: 10, // Max 10 reconnect attempts
+    reconnectInterval: 3000 // Try reconnecting every 3s
+  })
+
+  // Update state when a new message arrives
   useEffect(() => {
-    if (ws.current) {
-      ws.current.close()
+    if (lastJsonMessage !== null) {
+      console.log('Received WebSocket message:', lastJsonMessage)
+      setData(lastJsonMessage as DashboardData)
     }
+  }, [lastJsonMessage])
 
-    ws.current = new WebSocket(url)
-
-    ws.current.onopen = () => {
-      setIsConnected(true)
-      console.log('WebSocket connection established')
-    }
-
-    ws.current.onmessage = (event) => {
-      try {
-        const newData: DashboardData = JSON.parse(
-          event.data as string
-        ) as DashboardData
-        if (
-          isDashboardData(newData) &&
-          hasDataChanged(newData, latestData.current)
-        ) {
-          latestData.current = newData
-          setData(newData) // React state triggers re-render
-        }
-      } catch (error) {
-        console.error('Error parsing WebSocket message', error)
-      }
-    }
-
-    ws.current.onerror = (error) => {
-      console.error('WebSocket error', error)
-    }
-
-    ws.current.onclose = () => {
-      setIsConnected(false)
-      console.log('WebSocket connection closed')
-      ws.current = null // Ensure WebSocket is reset
-    }
-
-    return () => {
-      ws.current?.close()
-    }
-  }, [url]) //Depend only on `url` to avoid re-creating unnecessary WebSockets
-
-  // To be able to send messages to the backend
-  const sendMessage = (message: string) => {
-    if (ws.current && ws.current.readyState === WebSocket.OPEN) {
-      ws.current.send(message)
+  // Function to send a message
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sendMessage = (message: any) => {
+    if (readyState === ReadyState.OPEN) {
+      console.log('📤 Sending WebSocket message:', message)
+      sendJsonMessage(message)
     } else {
-      console.warn('WebSocket is not open')
+      console.warn('WebSocket is not open, cannot send message.')
     }
   }
 
-  function isDashboardData(
-    data: DashboardData | string
-  ): data is DashboardData {
-    return (
-      typeof data === 'object' &&
-      data !== null &&
-      'position_pri' in data &&
-      'position_sec' in data &&
-      'angle_pri' in data &&
-      'angle_sec' in data &&
-      'pos_setpoint_pri' in data &&
-      'pos_setpoint_sec' in data
-    )
-  }
-
-  function hasDataChanged(
-    newData: DashboardData,
-    oldData: DashboardData
-  ): boolean {
-    return (
-      newData.position_pri !== oldData.position_pri ||
-      newData.position_sec !== oldData.position_sec ||
-      newData.angle_pri !== oldData.angle_pri ||
-      newData.angle_sec !== oldData.angle_sec ||
-      newData.pos_setpoint_pri !== oldData.pos_setpoint_pri ||
-      newData.pos_setpoint_sec !== oldData.pos_setpoint_sec
-    )
-  }
-
-  return { data, isConnected, sendMessage }
+  return { data, isConnected: readyState === ReadyState.OPEN, sendMessage }
 }

--- a/dashboard/src/pages/MiniDashboard.tsx
+++ b/dashboard/src/pages/MiniDashboard.tsx
@@ -10,10 +10,12 @@ import { DashboardData } from '../types/DashboardData'
 
 export function MiniDashboard() {
   const initialData: DashboardData = {
-    currentThrust: 20,
-    currentAngle: 80, // Between -90 and 90
-    consumption: 0,
-    currentEmissions: 20,
+    position_pri: 0,
+    angle_pri: 0,
+    position_sec: 0,
+    angle_sec: 0,
+    pos_setpoint_pri: 0,
+    pos_setpoint_sec: 0
   }
 
   const data = UseWebSocket('ws://127.0.0.1:8000/ws', initialData)
@@ -23,19 +25,21 @@ export function MiniDashboard() {
       <Tabs>
         <TabPanel>
           <MemoizedAzimuthThruster
-            thrust={data.data.currentThrust}
-            angle={data.data.currentAngle}
-            setPoint={10}
+            thrust={data.data.position_pri}
+            angle={data.data.angle_pri}
+            angleSetpoint={0}
+            thrustSetPoint={0}
+            onSetPointChange={() => {}} // Dummy function
             touching={true}
             atThrustSetpoint={false}
             atAngleSetpoint={false}
           />
         </TabPanel>
         <TabPanel>
-          <MemoizedRudder angle={data.data.currentAngle} />
+          <MemoizedRudder angle={data.data.angle_pri} />
         </TabPanel>
         <TabPanel>
-          <MemoizedThruster thrust={data.data.currentThrust} />
+          <MemoizedThruster thrust={data.data.position_pri} />
         </TabPanel>
         <TabList>
           <Tab>Azimuth</Tab>

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -78,7 +78,7 @@
 
 /* Start Button */
 .button:first-child {
-  background-color: #4CAF50; /* Green */
+  background-color: #4caf50; /* Green */
   color: white;
 }
 
@@ -87,7 +87,6 @@
   background-color: #d9534f; /* Red */
   color: white;
 }
-
 
 /* Styling for the AzimuthThruster Component TODO: not in use 
 .azimuth-thruster-container {

--- a/dashboard/src/styles/startup.css
+++ b/dashboard/src/styles/startup.css
@@ -22,7 +22,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: flex-start; 
+  align-items: flex-start;
   width: 80%;
   max-width: 1200px;
 }
@@ -80,7 +80,7 @@
   font-weight: bold;
   margin-bottom: 10px;
   display: block;
-  align-self:center; /* Aligns to the left */
+  align-self: center; /* Aligns to the left */
 }
 
 /* Ensures select stays below label */
@@ -128,7 +128,8 @@
     align-items: center;
   }
 
-  .info-section, .config-selection {
+  .info-section,
+  .config-selection {
     max-width: 80%;
     width: 100%;
     margin-bottom: 20px;
@@ -140,7 +141,8 @@
     font-size: 2.2rem;
   }
 
-  .info-section, .config-selection {
+  .info-section,
+  .config-selection {
     max-width: 100%;
     padding: 20px;
   }

--- a/dashboard/src/types/ConfigFiles.ts
+++ b/dashboard/src/types/ConfigFiles.ts
@@ -1,3 +1,3 @@
 export type ConfigFiles = {
-    files: string [];
-};
+  files: string[]
+}

--- a/dashboard/src/types/ConfigResponse.ts
+++ b/dashboard/src/types/ConfigResponse.ts
@@ -1,6 +1,4 @@
 export type ConfigResponse = {
-    message?: string;
-    error?: string;
-  };
-
-  
+  message?: string
+  error?: string
+}

--- a/dashboard/src/types/SimulationContext.ts
+++ b/dashboard/src/types/SimulationContext.ts
@@ -1,4 +1,4 @@
 export type SimulationContextType = {
-    simulationRunning: boolean;
-    setSimulationRunning: (running: boolean) => void;
-  };
+  simulationRunning: boolean
+  setSimulationRunning: (running: boolean) => void
+}


### PR DESCRIPTION
This PR refactors and improves setpoint handling in both the frontend and backend, ensuring smoother communication between components via WebSockets. It also enhances WebSocket stability, preventing unexpected disconnections.

**Frontend**:
- Implemented setpoint logic for thrust and angle in the AzimuthThruster component.
- Sliders now properly (almost) update and send setpoints via WebSocket.
- Prevented NaN/undefined values from breaking UI rendering.
- Replaced custom WebSocket logic with react-use-websocket to improve stability.

**Backend**:
- WebSocket now handles and stores setpoints (but not sure if correctly as i cannot test right now).
- Added logic to update the AzimuthController with new setpoints.
- Improved logging to track WebSocket messages and client connections.

**WebSockets**:
- Resolved random disconnects by using a more reliable WebSocket package.
- WebSocket state is now properly tracked, reducing redundant updates.
- Improved handling of incoming messages to ensure correct data flow.

**Next Steps**
- Verify integration with real hardware.
- The state handling of setpoint changes in not correct when sent by the websocket to the backend (one step behing) - perhaps add state to context instead of useState hook? 