### PR TITLE
43 use large azimuth component in the interface

### DIFF
--- a/frontend/src/components/AzimuthThruster.tsx
+++ b/frontend/src/components/AzimuthThruster.tsx
@@ -25,7 +25,7 @@ export function AzimuthThruster({
   onSetPointChange
 }: AzimuthThrusterProps) {
   return (
-    <div className="dashboard-component">
+    <div className="azimuth-thruster">
       <ObcAzimuthThruster
         thrust={thrust}
         angle={angle}

--- a/frontend/src/components/InstrumentField.tsx
+++ b/frontend/src/components/InstrumentField.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { ObcInstrumentField } from '@oicl/openbridge-webcomponents-react/navigation-instruments/instrument-field/instrument-field'
 import { InstrumentFieldSize } from '@oicl/openbridge-webcomponents/dist/navigation-instruments/instrument-field/instrument-field'
 import '../styles/dashboard.css'
@@ -26,9 +27,32 @@ export function InstrumentField({
   tag = '',
   unit = '',
   source = '',
-  hasSource = false,
-  size = InstrumentFieldSize.small
+  hasSource = false
 }: InstrumentFieldProps) {
+  const [instrumentSize, setInstrumentSize] = useState<InstrumentFieldSize>(
+    InstrumentFieldSize.small
+  )
+
+  // Listening for changes in window size
+  useEffect(() => {
+    const updateSize = () => {
+      const width = window.innerWidth
+
+      if (width < 1200) {
+        setInstrumentSize(InstrumentFieldSize.small)
+      } else if (width >= 1200 && width < 1600) {
+        setInstrumentSize(InstrumentFieldSize.regular)
+      } else {
+        setInstrumentSize(InstrumentFieldSize.large)
+      }
+    }
+
+    updateSize() // Call once initially
+    window.addEventListener('resize', updateSize)
+
+    return () => window.removeEventListener('resize', updateSize)
+  }, [])
+
   return (
     <div className="instrument-field">
       <ObcInstrumentField
@@ -42,7 +66,7 @@ export function InstrumentField({
         unit={unit}
         source={source}
         hasSource={hasSource}
-        size={size}
+        size={instrumentSize}
       ></ObcInstrumentField>
     </div>
   )

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -11,7 +11,8 @@ import { DashboardData, SimulatorData } from '../types/DashboardData'
 import {
   toHeading,
   gramsToKiloGrams,
-  calculateAverage
+  calculateAverage,
+  newtonsToKiloNewtons
 } from '../utils/Convertion'
 import { useSimulation } from '../hooks/useSimulation'
 
@@ -196,6 +197,7 @@ export function Dashboard() {
             <InstrumentField
               value={simulatorData.rpm}
               tag="RPM"
+              maxDigits={4}
               source="Simulator"
               hasSource={true}
             ></InstrumentField>
@@ -242,7 +244,7 @@ export function Dashboard() {
               hasSetPoint={true}
               value={simulatorData.xPos}
               degree={false}
-              maxDigits={3}
+              maxDigits={4}
               fractionDigits={1}
               tag="X"
               unit="m"
@@ -254,7 +256,7 @@ export function Dashboard() {
               hasSetPoint={true}
               value={simulatorData.yPos}
               degree={false}
-              maxDigits={3}
+              maxDigits={4}
               fractionDigits={1}
               tag="Y"
               unit="m"
@@ -290,16 +292,16 @@ export function Dashboard() {
               unit="kg"
               source="Simulator"
               hasSource={true}
-              maxDigits={6}
+              maxDigits={4}
               fractionDigits={2}
             ></InstrumentField>
             <InstrumentField
-              value={simulatorData.resistance}
+              value={newtonsToKiloNewtons(simulatorData.resistance)}
               tag="Res"
-              unit="N"
+              unit="KN"
               source="Simulator"
               hasSource={true}
-              maxDigits={6}
+              maxDigits={4}
               fractionDigits={1}
             ></InstrumentField>
           </div>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1,222 +1,226 @@
-/* Ensure the dashboard takes up the full screen */
-.dashboard {
-  display: flex;
-  flex-direction: row; /* Side-by-side layout */
-  height: 100vh; /* Full viewport height */
-  width: 100vw; /* Full viewport width */
-  overflow: hidden;
-}
+  /* Ensure the dashboard takes up the full screen */
+  .dashboard {
+    display: flex;
+    flex-direction: row; /* Side-by-side layout */
+    height: 100vh; /* Full viewport height */
+    width: 100vw; /* Full viewport width */
+    overflow: hidden;
+  }
 
-/* Fix the simulator panel to take full available space */
-.simulator-panel {
-  width: 70%;
-  height: 100vh; /* Full viewport height */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: black; /* Debugging: Ensure it's visible */
-  position: relative; /* Ensures child iframe can stretch */
-}
+  /* Fix the simulator panel to take full available space */
+  .simulator-panel {
+    flex: 1;
+    min-width: 60%;
+    max-width: 70%;
+    height: 100vh; /* Full viewport height */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: black; /* Debugging: Ensure it's visible */
+    position: relative; /* Ensures child iframe can stretch */
+  }
 
-/* Ensure the iframe fills the simulator panel //TODO 509px */
-.simulator-panel iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
-  display: block;
-}
-/* UI Panel: Right Side (Azimuth Thruster + Data) */
-.ui-panel {
-  width: 30%;
-  height: 100%;
-  display: flex;
-  flex-direction: column; /* Ensure vertical stacking */
-  padding: 20px; /* Adds spacing */
-  gap: 10px; /* Adds space between components */
-  background-color: #f8f8f8; /* Light background */
-  overflow-y: auto; /* Allows scrolling if too much content */
-  text-align: center;
-}
+  /* Ensure the iframe fills the simulator panel //TODO 509px */
+  .simulator-panel iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    display: block;
+  }
+  /* UI Panel: Right Side (Azimuth Thruster + Data) */
+  .ui-panel {
+    flex: 0.3; /* Ensures it is 30% of the width */
+    min-width: 30%;
+    max-width: 40%;
+    height: 100%;
+    display: flex;
+    flex-direction: column; /* Ensure vertical stacking */
+    padding: 20px; /* Adds spacing */
+    gap: 10px; /* Adds space between components */
+    background-color: #f8f8f8; /* Light background */
+    overflow-y: auto; /* Allows scrolling if too much content */
+    text-align: center;
+  }
 
-.ui-panel h3 {
-  font-size: 16px;
-  margin-bottom: 5px;
-  color: #333;
-}
+  .ui-panel h3 {
+    font-size: 16px;
+    margin-bottom: 5px;
+    color: #333;
+  }
 
-.dashboard-component {
-  height: 150px;
-  width: 300px;
-  min-height: 30%;
-  min-width: 30%;
-}
+  .dashboard-component {
+    height: 150px;
+    width: 300px;
+    min-height: 30%;
+    min-width: 30%;
+  }
 
-.azimuth-thruster {
-  height: 200px;
-  width: 400px;
-  min-height: 30%;
-  min-width: 30%;
-}
+  .azimuth-thruster {
+    height: 400px;
+    width: 100%;
+    max-height: 35vh; /* Allow it to scale dynamically */
+    min-height: 200px;
+  }
 
-.button-row {
-  display: flex;
-  justify-content: center; /* Center the buttons */
-  gap: 15px; /* Add space between buttons */
-  margin-bottom: 15px; /* Add space below the buttons */
-}
+  .button-row {
+    display: flex;
+    justify-content: center; /* Center the buttons */
+    gap: 15px; /* Add space between buttons */
+    margin-bottom: 15px; /* Add space below the buttons */
+  }
 
-.button {
-  padding: 10px 20px;
-  font-size: 16px;
-  font-weight: bold;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-}
+  .button {
+    padding: 10px 20px;
+    font-size: 16px;
+    font-weight: bold;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+  }
 
-.button:hover {
-  opacity: 0.8;
-}
+  .button:hover {
+    opacity: 0.8;
+  }
 
-.button:active {
-  transform: scale(0.98);
-}
+  .button:active {
+    transform: scale(0.98);
+  }
 
-/* Start Button */
-.button:first-child {
-  background-color: #4caf50; /* Green */
-  color: white;
-}
+  /* Start Button */
+  .button:first-child {
+    background-color: #4caf50; /* Green */
+    color: white;
+  }
 
-/* Stop Button */
-.button:last-child {
-  background-color: #d9534f; /* Red */
-  color: white;
-}
+  /* Stop Button */
+  .button:last-child {
+    background-color: #d9534f; /* Red */
+    color: white;
+  }
 
-/* Styling for the AzimuthThruster Component TODO: not in use 
-.azimuth-thruster-container {
+  /* Styling for the AzimuthThruster Component TODO: not in use 
+  .azimuth-thruster-container {
+      width: 90%;
+      max-width: 500px;// Prevents it from taking up the full width
+      padding: 20px;
+      background: white;
+      border-radius: 10px;
+      box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+  }
+  */
+  /* Information panel */
+  .info-panel {
+    margin-top: 20px;
     width: 90%;
-    max-width: 500px;// Prevents it from taking up the full width
-    padding: 20px;
+    max-width: 500px;
+    padding: 15px;
     background: white;
     border-radius: 10px;
     box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
+    text-align: left;
+  }
+
+  .info-panel h3 {
+    font-size: 16px;
+    margin-bottom: 5px;
+    color: #333;
+  }
+
+  .info-panel p {
+    font-size: 14px;
+    margin: 2px 0;
+    color: #555;
+  }
+
+  .info-card {
+    width: 90%;
+    max-width: 400px;
+    padding: 15px;
+    margin-bottom: 15px;
+    color: #333;
+  }
+
+  .info-card h3 {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    text-align: center;
+  }
+
+  .info-card p {
+    font-size: 14px;
+    margin: 5px 0;
+    text-align: left;
+  }
+
+  .mini-dashboard {
+    height: 420px;
+    width: 640px;
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-}
-*/
-/* Information panel */
-.info-panel {
-  margin-top: 20px;
-  width: 90%;
-  max-width: 500px;
-  padding: 15px;
-  background: white;
-  border-radius: 10px;
-  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
-  text-align: left;
-}
+    flex-direction: column;
+  }
 
-.info-panel h3 {
-  font-size: 16px;
-  margin-bottom: 5px;
-  color: #333;
-}
+  /* Tab text is grey when not selected and black when selected */
+  .react-tabs__tab {
+    color: grey;
+    font-weight: 500;
+    padding: 10px 20px;
+    cursor: pointer;
+    border-radius: 5px;
+    transition: color 0.3s ease-in-out;
+    border: none !important;
+    box-shadow: none !important;
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+  }
 
-.info-panel p {
-  font-size: 14px;
-  margin: 2px 0;
-  color: #555;
-}
+  .react-tabs__tab--selected {
+    color: black !important;
+    font-weight: bold;
+    background-color: #f7f7f7 !important;
+    border-bottom: none !important;
+    box-shadow: none !important;
+    outline: none !important;
+  }
 
-.info-card {
-  width: 90%;
-  max-width: 400px;
-  padding: 15px;
-  margin-bottom: 15px;
-  color: #333;
-}
+  .react-tabs__tab--selected::after {
+    display: none !important;
+  }
 
-.info-card h3 {
-  font-size: 18px;
-  font-weight: bold;
-  margin-bottom: 10px;
-  text-align: center;
-}
+  .instrument-field {
+    padding: 4px;
+  }
 
-.info-card p {
-  font-size: 14px;
-  margin: 5px 0;
-  text-align: left;
-}
+  /* Make sure the tabs are inside the dashboard */
+  .react-tabs__tab-list {
+    width: 100%;
+    min-height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    background-color: #f7f7f7; /* Ensure it blends with the dashboard */
+    position: relative; /* Keeps it inside the dashboard */
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 0; /* Moves it to the bottom */
+    border-bottom: none !important;
+  }
 
-.mini-dashboard {
-  height: 420px;
-  width: 640px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-}
+  .top-bar {
+    width: 100% !important;
+    padding: 10px;
+  }
 
-/* Tab text is grey when not selected and black when selected */
-.react-tabs__tab {
-  color: grey;
-  font-weight: 500;
-  padding: 10px 20px;
-  cursor: pointer;
-  border-radius: 5px;
-  transition: color 0.3s ease-in-out;
-  border: none !important;
-  box-shadow: none !important;
-  min-height: 40px;
-  display: flex;
-  align-items: center;
-}
-
-.react-tabs__tab--selected {
-  color: black !important;
-  font-weight: bold;
-  background-color: #f7f7f7 !important;
-  border-bottom: none !important;
-  box-shadow: none !important;
-  outline: none !important;
-}
-
-.react-tabs__tab--selected::after {
-  display: none !important;
-}
-
-.instrument-field {
-  padding: 4px;
-}
-
-/* Make sure the tabs are inside the dashboard */
-.react-tabs__tab-list {
-  width: 100%;
-  min-height: 40px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  background-color: #f7f7f7; /* Ensure it blends with the dashboard */
-  position: relative; /* Keeps it inside the dashboard */
-  left: 50%;
-  transform: translateX(-50%);
-  bottom: 0; /* Moves it to the bottom */
-  border-bottom: none !important;
-}
-
-.top-bar {
-  width: 100% !important;
-  padding: 10px;
-}
-
-hr.solid {
-  width: 80%;
-  border-top: 1px solid rgb(207, 207, 207);
-}
+  hr.solid {
+    width: 80%;
+    border-top: 1px solid rgb(207, 207, 207);
+  }

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -51,6 +51,13 @@
   min-width: 30%;
 }
 
+.azimuth-thruster {
+  height: 200px;
+  width: 400px;
+  min-height: 30%;
+  min-width: 30%;
+}
+
 .button-row {
   display: flex;
   justify-content: center; /* Center the buttons */

--- a/frontend/src/utils/Convertion.tsx
+++ b/frontend/src/utils/Convertion.tsx
@@ -20,3 +20,8 @@ export function calculateAverage(arr: number[]) {
     ? arr.reduce((sum, value) => sum + value, 0) / arr.length
     : 0
 }
+
+// Newtons to kiloNewtons
+export function newtonsToKiloNewtons(newtons: number) {
+  return newtons / 1000
+}


### PR DESCRIPTION
This PR improves the scalability and responsiveness of UI, also including the Azimuth Thruster and Instrument Panels to enhance usability on different screen sizes. 

Changes Implemented
- Azimuth Thruster is the largest component now in the UI. 
- Azimuth Thruster relatively keeps its large size as the window size increases. 
- Dynamic Sizing for UI Components:
-Instrument Panels now resize dynamically based on window width (small, regular, large)
- Refactored InstrumentField Component by introducing useEffect + useState to dynamically adjust the InstrumentFieldSize. The breakpoints used were:
  - <1200px → Small
  - 1200px - 1599px → Regular
  - ≥1600px → Large
- Improved Layout in dashboard.css:
  - UI panel now takes 30-40% of screen width (flex-based scaling).
  - Simulator panel correctly expands to 60-70% width.
- Converted Newtons to Kilo-Newtons to save space in the UI.

Why These Changes?
- Enhances readability and usability on different screen resolutions.
- Improves user interaction with the Azimuth Thruster controls (hoping that the large size will attract attention during eye-tracking).
- Future-proofs the UI for various display sizes and devices (especially regarding unknown screen size during future experiments).