### PR TITLE
47 display alert zones for both thruster and azimuth angle in the UI

### DIFF
--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -24,7 +24,7 @@ class Dashboard:
         
         # Mock data generators
         self.mock_thrust = itertools.cycle([70,80,90,100,90,80,70])  # Simulates increasing & decreasing thrust
-        self.mock_angle = itertools.cycle([0, 15, 30, 45, 50,60,70,80,90,100,30, 15, 0, -15, -30, -45, -30, -15, 0])  # Oscillates rudder angle
+        self.mock_angle = itertools.cycle([0, 15, 30, 45, 50,60,70,80,90,100, 110, 120,130,140,150,160,180,170,160,150,130,120,110,100,90,80,70,60,50,40,30, 15, 0, -15, -30, -45, -60, -75, -90, -105,-120,-145,-160, -175, -160,-145,-120,-105,-90,-75,-60,-45, -30, -15, 0])  # Oscillates rudder angle
         
     def set_database(self, database: Database):
         """Assigns a database instance to the dashboard singleton."""

--- a/frontend/src/components/AzimuthThruster.tsx
+++ b/frontend/src/components/AzimuthThruster.tsx
@@ -2,6 +2,9 @@
 //import { ObcAzimuthThrusterLabeled } from '@oicl/openbridge-webcomponents-react/navigation-instruments/azimuth-thruster-labeled/azimuth-thruster-labeled'
 import { ObcAzimuthThruster } from '@oicl/openbridge-webcomponents-react/navigation-instruments/azimuth-thruster/azimuth-thruster'
 import '../styles/dashboard.css'
+import { AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
+import { AdviceType } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
+import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
 
 type AzimuthThrusterProps = {
   thrust: number //  The thrust of the thruster in percent (0-100)
@@ -12,6 +15,8 @@ type AzimuthThrusterProps = {
   atThrustSetpoint: boolean // Whether the thruster is at the setpoint
   atAngleSetpoint: boolean // Whether the angle is at the setpoint
   onSetPointChange: (type: 'thrust' | 'angle', value: number) => void // Callback function
+  angleAdvices: AngleAdvice[]
+  thrustAdvices: LinearAdvice[]
 }
 
 export function AzimuthThruster({
@@ -24,6 +29,19 @@ export function AzimuthThruster({
   atAngleSetpoint,
   onSetPointChange
 }: AzimuthThrusterProps) {
+  // Define angle alert zones
+  const angleAdvices: AngleAdvice[] = [
+    { minAngle: 20, maxAngle: 50, type: AdviceType.advice, hinted: true },
+    { minAngle: 75, maxAngle: 100, type: AdviceType.caution, hinted: true },
+    { minAngle: -100, maxAngle: -75, type: AdviceType.caution, hinted: true }
+  ]
+
+  // Define angle alert zones
+  const thrustAdvices: LinearAdvice[] = [
+    { min: 20, max: 50, type: AdviceType.advice, hinted: true },
+    { min: 60, max: 100, type: AdviceType.caution, hinted: true }
+  ]
+
   return (
     <div className="azimuth-thruster">
       <ObcAzimuthThruster
@@ -34,6 +52,8 @@ export function AzimuthThruster({
         touching={touching}
         atThrustSetpoint={atThrustSetpoint}
         atAngleSetpoint={atAngleSetpoint}
+        thrustAdvices={thrustAdvices}
+        angleAdvices={angleAdvices}
       ></ObcAzimuthThruster>
       <div className="setpoint-controls">
         <label>Thrust Setpoint</label>

--- a/frontend/src/components/AzimuthThruster.tsx
+++ b/frontend/src/components/AzimuthThruster.tsx
@@ -3,7 +3,6 @@
 import { ObcAzimuthThruster } from '@oicl/openbridge-webcomponents-react/navigation-instruments/azimuth-thruster/azimuth-thruster'
 import '../styles/dashboard.css'
 import { AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
-import { AdviceType } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
 import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
 
 type AzimuthThrusterProps = {
@@ -27,21 +26,10 @@ export function AzimuthThruster({
   touching,
   atThrustSetpoint,
   atAngleSetpoint,
+  angleAdvices,
+  thrustAdvices,
   onSetPointChange
 }: AzimuthThrusterProps) {
-  // Define angle alert zones
-  const angleAdvices: AngleAdvice[] = [
-    { minAngle: 20, maxAngle: 50, type: AdviceType.advice, hinted: true },
-    { minAngle: 75, maxAngle: 100, type: AdviceType.caution, hinted: true },
-    { minAngle: -100, maxAngle: -75, type: AdviceType.caution, hinted: true }
-  ]
-
-  // Define angle alert zones
-  const thrustAdvices: LinearAdvice[] = [
-    { min: 20, max: 50, type: AdviceType.advice, hinted: true },
-    { min: 60, max: 100, type: AdviceType.caution, hinted: true }
-  ]
-
   return (
     <div className="azimuth-thruster">
       <ObcAzimuthThruster

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,10 +1,12 @@
+import { AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
+import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
 import { AzimuthThruster } from '../components/AzimuthThruster'
 import { Compass } from '../components/Compass'
 import { InstrumentField } from '../components/InstrumentField'
 import { UseWebSocket } from '../hooks/useWebSocket'
 import { UseSimulatorWebSocket } from '../hooks/useSimulatorWebSocket'
 import { memo, useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import '../styles/dashboard.css'
 import '../styles/instruments.css'
 import { DashboardData, SimulatorData } from '../types/DashboardData'
@@ -15,6 +17,11 @@ import {
   newtonsToKiloNewtons
 } from '../utils/Convertion'
 import { useSimulation } from '../hooks/useSimulation'
+
+type LocationState = {
+  angleAdvices?: AngleAdvice[]
+  thrustAdvices?: LinearAdvice[]
+}
 
 export function Dashboard() {
   const { simulationRunning, setSimulationRunning } = useSimulation() // Retrieving simulation running state from context
@@ -59,6 +66,25 @@ export function Dashboard() {
     'ws://127.0.0.1:8000/ws',
     initialData
   )
+
+  // Alert zones
+  const location = useLocation()
+  const state = location.state as LocationState | null // Type casting for safety
+
+  // Fetch advices from location state (set in startup page) or use default values
+  const angleAdvices: AngleAdvice[] =
+    state?.angleAdvices ??
+    ([
+      { minAngle: 20, maxAngle: 50, type: 'advice', hinted: true },
+      { minAngle: 75, maxAngle: 100, type: 'caution', hinted: true }
+    ] as AngleAdvice[])
+
+  const thrustAdvices: LinearAdvice[] =
+    state?.thrustAdvices ??
+    ([
+      { min: 20, max: 50, type: 'advice', hinted: true },
+      { min: 60, max: 100, type: 'caution', hinted: true }
+    ] as LinearAdvice[])
 
   useEffect(() => {
     if (azimuthData) {
@@ -219,6 +245,8 @@ export function Dashboard() {
               touching={true}
               atThrustSetpoint={false}
               atAngleSetpoint={false}
+              angleAdvices={angleAdvices}
+              thrustAdvices={thrustAdvices}
               onSetPointChange={handleSetPointChange}
             />
           </div>


### PR DESCRIPTION
This PR introduces configurable alert zones for both thrust power and azimuth angle, allowing the moderator to define limits before simulation starts. The alert zones are visually indicated in the UI and propagate correctly to the Azimuth component. The startup UI now includes drop downs and input fields that are rather ugly, but function as an mvp for adjusting alert zones.

**Changes**:
- Alert zones are now configurable in the Startup page via input fields.
- Angle and Thrust advice zones propagate correctly to Dashboard.tsx and the AzimuthThruster component.
- Type safety improvements in Dashboard.tsx to prevent potential undefined errors when retrieving alert zones.
- Ensured visual and functional testing by modifying values and verifying in the simulator.

Why This Change?
- Provides more control over simulation conditions for the moderator.
- Ensures better feedback for operators, helping them adjust thruster usage based on safe operating ranges.
- Improves UI flexibility, making it easier to modify alert zones without hardcoded values.