### PR TITLE
50 haptic feedback adjustments based on alert zone proximity

### DIFF
--- a/backend/infrastructure/controller/azimuth_controller.py
+++ b/backend/infrastructure/controller/azimuth_controller.py
@@ -217,6 +217,33 @@ class AzimuthController:
             print(f"[ERROR] Unexpected error while writing setpoints: {e}")
             return False
     
+    def set_vibration(self, vibration_value: int):
+        """
+        Writes the vibration value to the Modbus register.
+
+        :param vibration_value: The vibration value to set (0 - 3).
+        """
+        if not self.client or not self.client.connected:
+            print("[ERROR] Not connected to Modbus. Cannot set vibration.")
+            return False
+
+        try:
+            # HREG 01 is used to set the vibration value
+            vibration_register = 0x01 # TODO correct address could easily be "1" instead of "0x01"
+
+            # Write vibration value
+            self.client.write_register(address=vibration_register, value=bool(vibration_value), slave=self.slave_id)
+            print(f"[INFO] Set vibration value to {vibration_value} at register {vibration_register}")
+
+            return True
+
+        except ModbusIOException as e:
+            print(f"[ERROR] Modbus IO Exception while writing vibration: {e}")
+            return False
+        except Exception as e:
+            print(f"[ERROR] Unexpected error while writing vibration: {e}")
+            return False
+        
 
     async def get_latest_data(self):
         """Provide the latest register data for external use."""

--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -78,6 +78,15 @@ class Dashboard:
                         logger.info("Setpoint successfully updated.")
                     else:
                         logger.error("Failed to update setpoint.")
+                
+                elif data.get("command") == "set_vibration":
+                    vibration = data.get("strength", 0)
+                    logger.info(f"Received vibration command: {vibration}")
+                    success = self.controller.set_vibration(vibration)
+                    if success:
+                        logger.info("Vibration successfully updated.")
+                    else:
+                        logger.error("Failed to update vibration.")
 
                 elif data.get("command") == "stop_simulation":
                     avg_speed = data.get("avg_speed", 0)

--- a/backend/persistance/database.py
+++ b/backend/persistance/database.py
@@ -1,6 +1,10 @@
 # Database connection and query handling - This is where the runs are stored and retrieved from the database
+import logging
 import sqlite3
 import asyncio
+
+logger = logging.getLogger("database")
+logging.basicConfig(level=logging.INFO)
 
 class Database:
     def __init__(self, db_name="runs.db"):
@@ -31,6 +35,7 @@ class Database:
             self._store_data_sync, 
             run_time, total_consumption, configuration_number, average_speed, average_rpm
         )
+        logger.info("Simulation data stored successfully.")
 
     def _store_data_sync(self, run_time, total_consumption, configuration_number, average_speed, average_rpm):
         """Insert a new record into the database (blocking function)."""

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -200,7 +200,7 @@ export function Dashboard() {
     const vibrationStrength = getVibrationStrength()
 
     if (vibrationStrength > 0 && alertConfig.enableVibration) {
-      console.log(`🚨 Sending vibration command: Strength ${vibrationStrength}`)
+      console.log(`Sending vibration command: Strength ${vibrationStrength}`)
 
       // Send vibration command to backend
       sendToBackend({
@@ -212,7 +212,7 @@ export function Dashboard() {
       if (vibrationStrength < alertConfig.vibrationRemain) {
         // TODO this depends on the meaning of "vibrationRemain"
         console.log(
-          `🚨 Stopping vibration after ${alertConfig.feedbackDuration}ms`
+          `Stopping vibration after ${alertConfig.feedbackDuration}ms`
         )
         setTimeout(() => {
           sendToBackend({
@@ -268,7 +268,7 @@ export function Dashboard() {
   }
 
   const handleSetPointChange = (type: 'thrust' | 'angle', value: number) => {
-    console.log(`🛠 Attempting to set ${type} to`, value) // ✅ Debugging log
+    console.log(`Attempting to set ${type} to`, value)
 
     // Update state immediately
     if (type === 'thrust') {

--- a/frontend/src/pages/MiniDashboard.tsx
+++ b/frontend/src/pages/MiniDashboard.tsx
@@ -33,6 +33,8 @@ export function MiniDashboard() {
             touching={true}
             atThrustSetpoint={false}
             atAngleSetpoint={false}
+            angleAdvices={[]}
+            thrustAdvices={[]}
           />
         </TabPanel>
         <TabPanel>

--- a/frontend/src/pages/Startup.tsx
+++ b/frontend/src/pages/Startup.tsx
@@ -12,6 +12,7 @@ import {
 import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
 
 import '../styles/startup.css'
+import { AlertConfig } from '../types/AlertConfig'
 
 export function Startup() {
   const [configFiles, setConfigFiles] = useState<string[]>([])
@@ -19,6 +20,21 @@ export function Startup() {
 
   const navigate = useNavigate()
   const { setSimulationRunning } = useSimulation()
+
+  // Alert zone settings
+  const [alertConfig, setAlertConfig] = useState<AlertConfig>({
+    vibrationApproach: 1,
+    vibrationEnter: 2,
+    vibrationRemain: 3,
+    resistanceApproach: 0,
+    resistanceEnter: 1,
+    resistanceRemain: 2,
+    detents: false,
+    feedbackDuration: 4000, // Default 4s
+    enableVibration: true,
+    enableResistance: false,
+    enableDetents: false
+  })
 
   const initialSimData: SimulatorData = {
     heading: 90,
@@ -129,7 +145,7 @@ export function Startup() {
       sendToSimulator(JSON.stringify({ command: 'start_simulation' }))
       // Pass alert zones via navigation state
       await navigate('/simulator', {
-        state: { angleAdvices, thrustAdvices }
+        state: { angleAdvices, thrustAdvices, alertConfig }
       })
     } catch (error) {
       console.error('Failed to start simulation:', error)
@@ -166,7 +182,7 @@ export function Startup() {
 
       {/* Alert Zone Configuration */}
       <div className="alert-config">
-        <h3>Set Alert Zones</h3>
+        <h3>Configure Alert Zones</h3>
 
         <h4>Angle Alerts</h4>
         {angleAdvices.map((advice, index) => (
@@ -196,7 +212,6 @@ export function Startup() {
             </select>
           </div>
         ))}
-
         <h4>Thrust Alerts</h4>
         {thrustAdvices.map((advice, index) => (
           <div key={index} className="alert-input">
@@ -225,11 +240,104 @@ export function Startup() {
             </select>
           </div>
         ))}
-      </div>
+        <div className="alert-config-container">
+          <h3>Haptic Feedback Configuration</h3>
 
-      <button onClick={() => void startSimulation()} className="start-button">
-        Start Simulation
-      </button>
+          {[
+            {
+              key: 'vibrationApproach',
+              label: 'Vibration (Approaching)',
+              tooltip: 'Vibration strength when approaching alert zone'
+            },
+            {
+              key: 'vibrationEnter',
+              label: 'Vibration (Entering)',
+              tooltip: 'Vibration strength when entering alert zone'
+            },
+            {
+              key: 'vibrationRemain',
+              label: 'Vibration (Remaining)',
+              tooltip: 'Vibration strength when remaining in alert zone'
+            },
+            {
+              key: 'feedbackDuration',
+              label: 'Feedback Duration (ms)',
+              tooltip: 'How long feedback lasts (except remaining inside)'
+            }
+          ].map(({ key, label, tooltip }) => (
+            <div key={key} className="label-container">
+              <div className="label-wrapper">
+                <span className="info-icon" data-tooltip={tooltip}>
+                  ℹ
+                </span>
+                <label>{label}</label>
+              </div>
+              <input
+                type="number"
+                value={
+                  typeof alertConfig[key as keyof AlertConfig] === 'boolean'
+                    ? Number(alertConfig[key as keyof AlertConfig])
+                    : alertConfig[key as keyof AlertConfig].toString()
+                }
+                onChange={(e) =>
+                  setAlertConfig((prev) => ({
+                    ...prev,
+                    [key]: Number(e.target.value)
+                  }))
+                }
+              />
+            </div>
+          ))}
+
+          {/* Checkbox options */}
+          <div className="label-container">
+            <div className="label-wrapper">
+              <span
+                className="info-icon"
+                data-tooltip="Enable vibration feedback"
+              >
+                ℹ
+              </span>
+              <label>Enable Vibration</label>
+            </div>
+            <input
+              type="checkbox"
+              checked={alertConfig.enableVibration}
+              onChange={() =>
+                setAlertConfig((prev) => ({
+                  ...prev,
+                  enableVibration: !prev.enableVibration
+                }))
+              }
+            />
+          </div>
+
+          <div className="label-container">
+            <div className="label-wrapper">
+              <span
+                className="info-icon"
+                data-tooltip="Enable resistance feedback"
+              >
+                ℹ
+              </span>
+              <label>Enable Resistance</label>
+            </div>
+            <input
+              type="checkbox"
+              checked={alertConfig.enableResistance}
+              onChange={() =>
+                setAlertConfig((prev) => ({
+                  ...prev,
+                  enableResistance: !prev.enableResistance
+                }))
+              }
+            />
+          </div>
+        </div>
+        <button onClick={() => void startSimulation()} className="start-button">
+          Start Simulation
+        </button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/styles/startup.css
+++ b/frontend/src/styles/startup.css
@@ -7,6 +7,7 @@
   height: 100vh;
   width: 100vw;
   color: #333;
+  overflow: auto;
 }
 
 /* Title Styling */
@@ -150,4 +151,84 @@
   .start-button {
     width: 100%;
   }
+}
+
+
+/* Alert Configuration Panel */
+.alert-config-container {
+  margin-top: 20px;
+  padding: 15px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content:stretch;
+  gap: 10px;
+  width: 90%;
+  max-width: 600px;
+}
+
+/* Ensures the labels and info icons are side by side */
+.label-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px; /* Space between icon and label */
+  width: 200px; /* Ensures consistency in width */
+}
+
+/* Aligns labels and inputs in a column */
+.label-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+/* Ensures all inputs are the same width and align vertically */
+.label-container input {
+  flex: 1;  /* Makes inputs expand evenly */
+  min-width: 100px;
+  max-width: 150px;
+  padding: 5px;
+}
+
+/* Ensures checkboxes are aligned correctly */
+.label-container input[type='checkbox'] {
+  width: auto;
+  min-width: 20px;
+  min-height: 20px;
+  border-radius: 2px;
+}
+
+/* Aligns info icon properly */
+.info-icon {
+  cursor: pointer;
+  font-size: 14px;
+  background-color: #007bff;
+  color: white;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  position: relative;
+}
+
+/* Tooltip for info icon */
+.info-icon:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  top: 120%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.75);
+  color: white;
+  padding: 5px;
+  font-size: 12px;
+  border-radius: 5px;
+  white-space: nowrap;
+  z-index: 10;
+  opacity: 1;
+  transition: opacity 0.3s;
 }

--- a/frontend/src/types/AlertConfig.ts
+++ b/frontend/src/types/AlertConfig.ts
@@ -1,0 +1,13 @@
+export type AlertConfig = {
+    vibrationApproach: number
+    vibrationEnter: number
+    vibrationRemain: number
+    resistanceApproach: number
+    resistanceEnter: number
+    resistanceRemain: number
+    detents: boolean
+    feedbackDuration: number
+    enableVibration: boolean
+    enableResistance: boolean
+    enableDetents: boolean
+  }


### PR DESCRIPTION
This PR introduces a way for the experiment moderator to configure alert zones and haptic feedback for the azimuth thruster. It also improves the WebSocket handling, ensuring real-time updates without interrupting simulation data.

Key Changes:
- Alert Zone Configuration:
  - Moderators can now configure angle and thrust alert zones in the Startup page.
  - Each alert zone can be set as Advice or Caution.
  - Adjustments are stored and propagated to the Dashboard.

- Haptic Feedback Configuration:
  - Customizable vibration intensity for approaching, entering, and remaining in an alert zone.
  - Ability to enable/disable vibration and resistance.
  - Adjustable feedback duration.
  - Info tooltips added to improve usability.

- WebSocket Improvements:
  - Refactored logic for handling incoming commands (set_setpoint, set_vibration).
  - Fixed issue where enabling vibration caused empty azimuth data responses.
  - Decoupled  fetch_data() by only fetching data in it, and moving sending data into send_live_updates() 

- Performance & Code Cleanup:
  - Memoization & Callbacks added to prevent unnecessary re-renders.
  - Logging improvements for debugging WebSocket messages.
  - Bug fix: Vibration updates no longer block thruster movement in the UI.
