### PR TITLE
58 styling of the setpoint sliders

### DIFF
--- a/frontend/src/components/AzimuthThruster.tsx
+++ b/frontend/src/components/AzimuthThruster.tsx
@@ -13,11 +13,9 @@ type AzimuthThrusterProps = {
   touching: boolean // Whether the thruster is being touched by the operator'
   atThrustSetpoint: boolean // Whether the thruster is at the setpoint
   atAngleSetpoint: boolean // Whether the angle is at the setpoint
-  onSetPointChange: (type: 'thrust' | 'angle', value: number) => void // Callback function
   angleAdvices: AngleAdvice[]
   thrustAdvices: LinearAdvice[]
 }
-
 export function AzimuthThruster({
   thrust,
   angle,
@@ -27,8 +25,7 @@ export function AzimuthThruster({
   atThrustSetpoint,
   atAngleSetpoint,
   angleAdvices,
-  thrustAdvices,
-  onSetPointChange
+  thrustAdvices
 }: AzimuthThrusterProps) {
   return (
     <div className="azimuth-thruster">
@@ -42,25 +39,7 @@ export function AzimuthThruster({
         atAngleSetpoint={atAngleSetpoint}
         thrustAdvices={thrustAdvices}
         angleAdvices={angleAdvices}
-      ></ObcAzimuthThruster>
-      <div className="setpoint-controls">
-        <label>Thrust Setpoint</label>
-        <input
-          type="range"
-          min="-100"
-          max="100"
-          value={thrustSetPoint}
-          onChange={(e) => onSetPointChange('thrust', Number(e.target.value))}
-        />
-        <label>Angle Setpoint</label>
-        <input
-          type="range"
-          min="-180"
-          max="180"
-          value={angleSetpoint}
-          onChange={(e) => onSetPointChange('angle', Number(e.target.value))}
-        />
-      </div>
+      />
     </div>
   )
 }

--- a/frontend/src/components/SetpointSliders.tsx
+++ b/frontend/src/components/SetpointSliders.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import '../styles/setpointSliders.css'
+
+type SetpointSlidersProps = {
+  thrustSetpoint: number
+  angleSetpoint: number
+  onSetPointChange: (type: 'thrust' | 'angle', value: number) => void
+}
+
+export function SetpointSliders({
+  thrustSetpoint,
+  angleSetpoint,
+  onSetPointChange
+}: SetpointSlidersProps) {
+  return (
+    <div className="setpoint-container">
+      <h3>Setpoints</h3>
+
+      <div className="setpoint-slider">
+        <label>
+          Thrust Setpoint: <span>{thrustSetpoint}%</span>
+        </label>
+        <input
+          type="range"
+          min="-100"
+          max="100"
+          value={thrustSetpoint}
+          onChange={(e) => onSetPointChange('thrust', Number(e.target.value))}
+          className="slider"
+        />
+      </div>
+
+      <div className="setpoint-slider">
+        <label>
+          Angle Setpoint: <span>{angleSetpoint}°</span>
+        </label>
+        <input
+          type="range"
+          min="-180"
+          max="180"
+          value={angleSetpoint}
+          onChange={(e) => onSetPointChange('angle', Number(e.target.value))}
+          className="slider"
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -20,6 +20,7 @@ import {
   newtonsToKiloNewtons
 } from '../utils/Convertion'
 import { useSimulation } from '../hooks/useSimulation'
+import { SetpointSliders } from '../components/SetpointSliders'
 
 type LocationState = {
   angleAdvices?: AngleAdvice[]
@@ -356,6 +357,12 @@ export function Dashboard() {
               atAngleSetpoint={false}
               angleAdvices={angleAdvices}
               thrustAdvices={thrustAdvices}
+            />
+          </div>
+          <div className="instrument-panel-row">
+            <SetpointSliders
+              thrustSetpoint={thrustSetpoint}
+              angleSetpoint={angleSetpoint}
               onSetPointChange={handleSetPointChange}
             />
           </div>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -35,8 +35,8 @@
     height: 100%;
     display: flex;
     flex-direction: column; /* Ensure vertical stacking */
-    padding: 20px; /* Adds spacing */
-    gap: 10px; /* Adds space between components */
+    padding: 20px; 
+    gap: 10px;
     background-color: #f8f8f8; /* Light background */
     overflow-y: auto; /* Allows scrolling if too much content */
     text-align: center;

--- a/frontend/src/styles/setpointSliders.css
+++ b/frontend/src/styles/setpointSliders.css
@@ -1,0 +1,50 @@
+.setpoint-container {
+    padding: 20px;
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 15px;
+    width: 100%;
+  }
+  
+  .setpoint-slider {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 90%;
+  }
+  
+  .setpoint-slider label {
+    font-size: 14px;
+    font-weight: bold;
+    margin-bottom: 5px;
+    text-align: center;
+    color: #333;
+  }
+  
+  .setpoint-slider span {
+    font-weight: bold;
+    color: #007bff;
+  }
+  
+  .slider {
+    width: 85%;
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
+    height: 6px;
+    border-radius: 5px;
+    background: #007bff;
+    outline: none;
+    transition: background-color 0.3s ease;
+  }
+  
+  .slider:hover {
+    opacity: 0.8;
+  }
+  
+  .slider:focus {
+    background: #0056b3;
+  }
+  


### PR DESCRIPTION
This PR decouples the setpoint sliders from the AzimuthThruster component and moves them into a dedicated SetpointSliders component. This change improves UI layout, spacing, and maintainability while preventing the sliders from overflowing into other sections.

**Created SetpointSliders.tsx**
- Allows independent adjustment of thrust and angle setpoints.
- Includes proper labels, values, and a modern slider UI.

**Updated dashboard.tsx**
- Removed setpoint sliders from AzimuthThruster.
- Added SetpointSliders component below propulsion.

**Added new styles in setpointSliders.css**
- Improved spacing, alignment, and interaction for sliders.
- Styled setpoint labels for better readability.

**Refactored AzimuthThruster.tsx**
- Removed unnecessary props related to setpoints.

**Why This Change?**
- Prevents UI overflow into the navigation section.
- Improves readability and modularization of components.
- Allows future styling and layout adjustments without affecting the thruster component.