### PR TITLE
40 measure reaction time for advice/guidance cues

### DIFF
--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -23,7 +23,7 @@ class Dashboard:
         self.database = None  
         
         # Mock data generators
-        self.mock_thrust = itertools.cycle([70,80,90,100,90,80,70])  # Simulates increasing & decreasing thrust
+        self.mock_thrust = itertools.cycle([40,50,60,70,80,90,100,90,80,70,60,50])  # Simulates increasing & decreasing thrust
         self.mock_angle = itertools.cycle([0, 15, 30, 45, 50,60,70,80,90,100, 110, 120,130,140,150,160,180,170,160,150,130,120,110,100,90,80,70,60,50,40,30, 15, 0, -15, -30, -45, -60, -75, -90, -105,-120,-145,-160, -175, -160,-145,-120,-105,-90,-75,-60,-45, -30, -15, 0])  # Oscillates rudder angle
         
     def set_database(self, database: Database):

--- a/frontend/src/components/ScenarioLogger.tsx
+++ b/frontend/src/components/ScenarioLogger.tsx
@@ -5,30 +5,35 @@ import '../styles/dashboard.css'
 
 export function ScenarioLogger({
   simulatorData,
-  simulationRunning
+  simulationRunning,
+  alertTriggered,
+  alertType
 }: {
   simulatorData: { position_pri: number; angle_pri: number }
   simulationRunning: boolean
+  alertTriggered: boolean
+  alertType?: 'advice' | 'caution' | null
 }) {
   const [isLogging, setIsLogging] = useState(false)
   const [logData, setLogData] = useState<
-    { timestamp: string; thrust: number; azimuthAngle: number }[]
+    {
+      timestamp: string
+      thrust: number
+      azimuthAngle: number
+      alertType: 'advice' | 'caution' | null | undefined
+    }[]
   >([])
   const [scenarioCount, setScenarioCount] = useState(1)
+  const [lastAlertTime, setLastAlertTime] = useState<number | null>(null)
 
   const startLogging = () => {
-    if (!simulationRunning) {
-      console.warn('Cannot start logging when simulation is not running.')
-      return
-    }
+    if (!simulationRunning) return
     setIsLogging(true)
     setLogData([])
-    console.log(`Started logging scenario ${scenarioCount}`)
   }
 
   const stopLogging = useCallback(() => {
     if (logData.length === 0) return
-
     const csv = Papa.unparse(logData)
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
     saveAs(blob, `scenario_${scenarioCount}.csv`)
@@ -36,40 +41,51 @@ export function ScenarioLogger({
     setIsLogging(false)
   }, [logData, scenarioCount])
 
+  // Capture T1 when alert is triggered
+  useEffect(() => {
+    if (isLogging && alertTriggered) {
+      console.log('🚨 Scenario Logger: Alert detected!')
+      setLastAlertTime(Date.now())
+    }
+  }, [alertTriggered, alertType, isLogging])
+
+  // Capture T2 when thrust or angle changes
   useEffect(() => {
     if (!isLogging) return
 
-    const newEntry = {
-      timestamp: new Date().toISOString(),
-      thrust: simulatorData.position_pri,
-      azimuthAngle: simulatorData.angle_pri
-    }
-    setLogData((prevData) => [...prevData, newEntry])
-  }, [simulatorData, isLogging])
+    const currentTime = Date.now()
+    let reactionTime = null
 
-  // Automatically stop logging when simulation stops
-  useEffect(() => {
-    if (!simulationRunning && isLogging) {
-      console.warn('Simulation stopped, automatically stopping logging.')
-      stopLogging()
+    if (lastAlertTime) {
+      reactionTime = currentTime - lastAlertTime
+      setLastAlertTime(null)
     }
-  }, [simulationRunning, isLogging, stopLogging])
 
-  const toggleLogging = () => {
-    if (isLogging) {
-      stopLogging()
-    } else {
-      startLogging()
-    }
-  }
+    setLogData((prevData) => [
+      ...prevData,
+      {
+        timestamp: new Date().toISOString(),
+        thrust: simulatorData.position_pri,
+        azimuthAngle: simulatorData.angle_pri,
+        reactionTime,
+        alertType
+      }
+    ])
+  }, [
+    simulatorData.position_pri,
+    simulatorData.angle_pri,
+    isLogging,
+    lastAlertTime,
+    alertType
+  ])
 
   return (
     <div className="scenario-logger">
       <button
-        onClick={toggleLogging}
-        className={`scenario-button ${isLogging ? 'stop' : 'start'}`}
+        onClick={() => (isLogging ? stopLogging() : startLogging())}
+        className="scenario-button"
       >
-        {isLogging ? 'Stop scenario' : 'Start scenario'}
+        {isLogging ? 'Stop Scenario' : 'Start Scenario'}
       </button>
     </div>
   )

--- a/frontend/src/components/ScenarioLogger.tsx
+++ b/frontend/src/components/ScenarioLogger.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { saveAs } from 'file-saver'
 import * as Papa from 'papaparse'
 import '../styles/dashboard.css'
@@ -6,86 +6,256 @@ import '../styles/dashboard.css'
 export function ScenarioLogger({
   simulatorData,
   simulationRunning,
-  alertTriggered,
-  alertType
+  thrustAdvices,
+  angleAdvices
 }: {
   simulatorData: { position_pri: number; angle_pri: number }
   simulationRunning: boolean
-  alertTriggered: boolean
-  alertType?: 'advice' | 'caution' | null
+  thrustAdvices: { min: number; max: number; type: 'advice' | 'caution' }[]
+  angleAdvices: {
+    minAngle: number
+    maxAngle: number
+    type: 'advice' | 'caution'
+  }[]
 }) {
   const [isLogging, setIsLogging] = useState(false)
+
   const [logData, setLogData] = useState<
     {
       timestamp: string
       thrust: number
       azimuthAngle: number
-      alertType: 'advice' | 'caution' | null | undefined
+      reactionTime?: number | null
+      exitTime?: number | null
+      alertType?: 'advice' | 'caution' | null
+      alertCategory?: 'thrust' | 'angle' // Marks if entry is thrust or angle
     }[]
   >([])
+
   const [scenarioCount, setScenarioCount] = useState(1)
-  const [lastAlertTime, setLastAlertTime] = useState<number | null>(null)
+
+  const lastAlertTime = useRef<{ thrust: number | null; angle: number | null }>(
+    {
+      thrust: null,
+      angle: null
+    }
+  ) // T1
+  const firstResponseTime = useRef<{
+    thrust: number | null
+    angle: number | null
+  }>({
+    thrust: null,
+    angle: null
+  }) // T2
+  const alertActive = useRef<{ thrust: boolean; angle: boolean }>({
+    thrust: false,
+    angle: false
+  })
+  const alertTypeRef = useRef<{
+    thrust: 'advice' | 'caution' | null
+    angle: 'advice' | 'caution' | null
+  }>({
+    thrust: null,
+    angle: null
+  })
+
+  const isStoppingRef = useRef<boolean>(false)
 
   const startLogging = () => {
-    if (!simulationRunning) return
+    if (!simulationRunning) {
+      console.warn('Cannot start logging when simulation is not running.')
+      return
+    }
     setIsLogging(true)
     setLogData([])
+    console.log(`Started logging scenario ${scenarioCount}`)
   }
 
   const stopLogging = useCallback(() => {
-    if (logData.length === 0) return
-    const csv = Papa.unparse(logData)
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-    saveAs(blob, `scenario_${scenarioCount}.csv`)
-    setScenarioCount(scenarioCount + 1)
-    setIsLogging(false)
+    if (isStoppingRef.current) return
+    isStoppingRef.current = true
+
+    setTimeout(() => {
+      // Ensure there is data before exporting
+      if (logData.length > 0) {
+        console.log('Exporting CSV...')
+        const csv = Papa.unparse(logData)
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+        saveAs(blob, `scenario_${scenarioCount}.csv`)
+
+        setScenarioCount((prev) => prev + 1)
+        console.log('CSV file saved.')
+      } else {
+        console.warn('No log data found, CSV not exported.')
+      }
+
+      setIsLogging(false)
+      isStoppingRef.current = false
+    }, 200)
   }, [logData, scenarioCount])
 
-  // Capture T1 when alert is triggered
+  // ** Capture T1 (Alert Triggered)**
   useEffect(() => {
-    if (isLogging && alertTriggered) {
-      console.log('🚨 Scenario Logger: Alert detected!')
-      setLastAlertTime(Date.now())
-    }
-  }, [alertTriggered, alertType, isLogging])
+    if (!isLogging) return
 
-  // Capture T2 when thrust or angle changes
+    let thrustAlertNow = false
+    let angleAlertNow = false
+
+    let detectedAngleType: 'advice' | 'caution' | null = null
+    let detectedThrustType: 'advice' | 'caution' | null = null
+
+    for (const advice of thrustAdvices) {
+      if (
+        simulatorData.position_pri >= advice.min &&
+        simulatorData.position_pri <= advice.max
+      ) {
+        thrustAlertNow = true
+        detectedThrustType = advice.type
+      }
+    }
+
+    for (const advice of angleAdvices) {
+      if (
+        simulatorData.angle_pri >= advice.minAngle &&
+        simulatorData.angle_pri <= advice.maxAngle
+      ) {
+        angleAlertNow = true
+        detectedAngleType = advice.type
+      }
+    }
+
+    // Log new thrust alert
+    if (thrustAlertNow && !alertActive.current.thrust) {
+      alertActive.current.thrust = true
+      lastAlertTime.current.thrust = Date.now()
+      alertTypeRef.current.thrust = detectedThrustType
+      firstResponseTime.current.thrust = null
+    }
+    // Log new angle alert
+    if (angleAlertNow && !alertActive.current.angle) {
+      alertActive.current.angle = true
+      lastAlertTime.current.angle = Date.now()
+      alertTypeRef.current.angle = detectedAngleType
+      firstResponseTime.current.angle = null
+    }
+  }, [simulatorData, thrustAdvices, angleAdvices, isLogging])
+
+  // ** Capture T2 (Operator Response)**
   useEffect(() => {
     if (!isLogging) return
 
     const currentTime = Date.now()
-    let reactionTime = null
 
-    if (lastAlertTime) {
-      reactionTime = currentTime - lastAlertTime
-      setLastAlertTime(null)
+    // Thrust response
+    if (
+      alertActive.current.thrust &&
+      firstResponseTime.current.thrust === null
+    ) {
+      firstResponseTime.current.thrust = currentTime
     }
 
-    setLogData((prevData) => [
-      ...prevData,
-      {
-        timestamp: new Date().toISOString(),
-        thrust: simulatorData.position_pri,
-        azimuthAngle: simulatorData.angle_pri,
-        reactionTime,
-        alertType
-      }
-    ])
-  }, [
-    simulatorData.position_pri,
-    simulatorData.angle_pri,
-    isLogging,
-    lastAlertTime,
-    alertType
-  ])
+    // Angle response
+    if (alertActive.current.angle && firstResponseTime.current.angle === null) {
+      firstResponseTime.current.angle = currentTime
+    }
+  }, [simulatorData, isLogging])
+
+  // ** Capture T3 (Exit Alert Zone)**
+  useEffect(() => {
+    if (!isLogging) return
+
+    const currentTime = new Date().toISOString()
+
+    // Check if thrust alert exits
+    if (
+      alertActive.current.thrust &&
+      !thrustAdvices.some(
+        (advice) =>
+          simulatorData.position_pri >= advice.min &&
+          simulatorData.position_pri <= advice.max
+      )
+    ) {
+      alertActive.current.thrust = false
+      const exitTime = Date.now() - (lastAlertTime.current.thrust ?? 0)
+
+      // Store in a single log with alertCategory = "thrust"
+      setLogData((prevData) => [
+        ...prevData,
+        {
+          timestamp: currentTime,
+          thrust: simulatorData.position_pri,
+          azimuthAngle: simulatorData.angle_pri,
+          reactionTime: firstResponseTime.current.thrust
+            ? firstResponseTime.current.thrust -
+              (lastAlertTime.current.thrust ?? 0)
+            : null,
+          exitTime: exitTime,
+          alertType: alertTypeRef.current.thrust,
+          alertCategory: 'thrust'
+        }
+      ])
+
+      lastAlertTime.current.thrust = null
+      firstResponseTime.current.thrust = null
+    }
+
+    // Check if angle alert exits
+    if (
+      alertActive.current.angle &&
+      !angleAdvices.some(
+        (advice) =>
+          simulatorData.angle_pri >= advice.minAngle &&
+          simulatorData.angle_pri <= advice.maxAngle
+      )
+    ) {
+      alertActive.current.angle = false
+      const exitTime = Date.now() - (lastAlertTime.current.angle ?? 0)
+
+      // Store in a single log with alertCategory = "angle"
+      setLogData((prevData) => [
+        ...prevData,
+        {
+          timestamp: currentTime,
+          thrust: simulatorData.position_pri,
+          azimuthAngle: simulatorData.angle_pri,
+          reactionTime: firstResponseTime.current.angle
+            ? firstResponseTime.current.angle -
+              (lastAlertTime.current.angle ?? 0)
+            : null,
+          exitTime: exitTime,
+          alertType: alertTypeRef.current.angle,
+          alertCategory: 'angle'
+        }
+      ])
+
+      lastAlertTime.current.angle = null
+      firstResponseTime.current.angle = null
+    }
+  }, [simulatorData, isLogging, thrustAdvices, angleAdvices])
+
+  // Automatically stop logging when simulation stops
+  useEffect(() => {
+    if (!simulationRunning && isLogging) {
+      console.warn('Simulation stopped, automatically stopping logging.')
+      stopLogging()
+    }
+  }, [simulationRunning, isLogging, stopLogging])
+
+  const toggleLogging = () => {
+    if (isLogging) {
+      stopLogging()
+    } else {
+      startLogging()
+    }
+  }
 
   return (
     <div className="scenario-logger">
       <button
-        onClick={() => (isLogging ? stopLogging() : startLogging())}
-        className="scenario-button"
+        onClick={toggleLogging}
+        className={`scenario-button ${isLogging ? 'stop' : 'start'}`}
       >
-        {isLogging ? 'Stop Scenario' : 'Start Scenario'}
+        {isLogging ? 'Stop scenario' : 'Start scenario'}
       </button>
     </div>
   )

--- a/frontend/src/hooks/useSimulatorWebSocket.tsx
+++ b/frontend/src/hooks/useSimulatorWebSocket.tsx
@@ -26,7 +26,6 @@ export function UseSimulatorWebSocket(
         ) as SimulatorData
         // Prevent overwriting with bad data (0 or NaN)
         if (!isValidData(message)) {
-          console.warn('Received invalid data, skipping update:', message)
           return
         }
         setData(message)

--- a/frontend/src/hooks/useWebSocket.tsx
+++ b/frontend/src/hooks/useWebSocket.tsx
@@ -18,7 +18,6 @@ export function UseWebSocket(url: string, initialData: DashboardData) {
   // Update state when a new message arrives
   useEffect(() => {
     if (lastJsonMessage !== null) {
-      console.log('Received WebSocket message:', lastJsonMessage)
       setData(lastJsonMessage as DashboardData)
     }
   }, [lastJsonMessage])
@@ -27,7 +26,6 @@ export function UseWebSocket(url: string, initialData: DashboardData) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sendMessage = (message: any) => {
     if (readyState === ReadyState.OPEN) {
-      console.log('📤 Sending WebSocket message:', message)
       sendJsonMessage(message)
     } else {
       console.warn('WebSocket is not open, cannot send message.')

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -36,7 +36,7 @@ export function Dashboard() {
   const [rpmData, setRpmData] = useState<number[]>([])
   //const [alertTriggered, setAlertTriggered] = useState<boolean>(false) // For logging purposes
   const [alertTime, setAlertTime] = useState<number | null>(null)
-  const [alertType, setAlertType] = useState<'advice' | 'caution' | null>(null)
+  const [, setAlertType] = useState<'advice' | 'caution' | null>(null)
   const navigate = useNavigate()
 
   // Keep track of last sent command
@@ -350,9 +350,9 @@ export function Dashboard() {
               position_pri: azimuthData.position_pri,
               angle_pri: azimuthData.angle_pri
             }}
+            thrustAdvices={thrustAdvices}
+            angleAdvices={angleAdvices}
             simulationRunning={simulationRunning}
-            alertTriggered={alertTriggeredRef.current}
-            alertType={alertType}
           />
           <button
             onClick={stopSimulation}


### PR DESCRIPTION
This PR enhances the ScenarioLogger by improving how we log the entry and exit of alert zones (thrust & angle), as well as when the operator reacts. It ensures that all relevant data is captured and exported properly.

**Key Changes**
- Added logging for both thrust and angle alert zones, ensuring both entry (T1) and exit (T3) are detected.
- Captures operator response time (T2) for both thrust and angle alerts.
- Fixes missing logs for thrust alerts, ensuring all alert zones are tracked correctly.
- Ensures CSV export works reliably after logging stops.
- Added mock data improvements for better testing and validation.
- Refactored logging logic to avoid duplicate code, making the system more maintainable.
- Decreased verbosity by removing unnecessary logs while keeping critical ones for debugging.

**How to Test**
- Start logging a scenario.
- Enter and exit both thrust and angle alert zones multiple times.
- Ensure logs are correctly captured in the console (T1, T2, T3) (in that case, the console logs must be rewritten in the code, as i have removed them currently).
- Stop logging and verify that a CSV file is generated with the expected data.
- Check that thrust and angle logs appear correctly in the exported CSV.

**Why This Change?**
Previously, logs were incomplete, missing thrust exit events, and sometimes CSVs weren’t exporting. This update ensures data consistency, better debugging, and cleaner exports for further analysis.