### PR TITLE
Config file and scenario id added to logging.

### DIFF
--- a/frontend/src/components/ScenarioLogger.tsx
+++ b/frontend/src/components/ScenarioLogger.tsx
@@ -24,7 +24,6 @@ export function ScenarioLogger({
   const [scenarioId, setScenarioId] = useState<string | null>(null)
   const [logData, setLogData] = useState<
     {
-      scenarioId: string
       timestamp: string
       thrust: number
       azimuthAngle: number
@@ -32,7 +31,6 @@ export function ScenarioLogger({
       exitTime?: number | null
       alertType?: 'advice' | 'caution' | null
       alertCategory?: 'thrust' | 'angle' // Marks if entry is thrust or angle
-      configFileName: string
     }[]
   >([])
 
@@ -90,7 +88,7 @@ export function ScenarioLogger({
         console.log('Exporting CSV...')
         const csv = Papa.unparse(logData)
         const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-        saveAs(blob, `scenario_${scenarioCount}.csv`)
+        saveAs(blob, `${scenarioId}-${configFileName}`)
 
         setScenarioCount((prev) => prev + 1)
         console.log('CSV file saved.')
@@ -101,7 +99,7 @@ export function ScenarioLogger({
       setIsLogging(false)
       isStoppingRef.current = false
     }, 200)
-  }, [logData, scenarioCount])
+  }, [logData, configFileName, scenarioId])
 
   // ** Capture T1 (Alert Triggered)**
   useEffect(() => {
@@ -191,8 +189,6 @@ export function ScenarioLogger({
       setLogData((prevData) => [
         ...prevData,
         {
-          scenarioId: scenarioId ?? '0',
-          configFileName: configFileName,
           timestamp: currentTime,
           thrust: simulatorData.position_pri,
           azimuthAngle: simulatorData.angle_pri,
@@ -226,8 +222,6 @@ export function ScenarioLogger({
       setLogData((prevData) => [
         ...prevData,
         {
-          scenarioId: scenarioId ?? '0',
-          configFileName: configFileName,
           timestamp: currentTime,
           thrust: simulatorData.position_pri,
           azimuthAngle: simulatorData.angle_pri,
@@ -244,14 +238,7 @@ export function ScenarioLogger({
       lastAlertTime.current.angle = null
       firstResponseTime.current.angle = null
     }
-  }, [
-    simulatorData,
-    isLogging,
-    thrustAdvices,
-    angleAdvices,
-    configFileName,
-    scenarioId
-  ])
+  }, [simulatorData, isLogging, thrustAdvices, angleAdvices])
 
   // Automatically stop logging when simulation stops
   useEffect(() => {

--- a/frontend/src/components/ScenarioLogger.tsx
+++ b/frontend/src/components/ScenarioLogger.tsx
@@ -7,7 +7,8 @@ export function ScenarioLogger({
   simulatorData,
   simulationRunning,
   thrustAdvices,
-  angleAdvices
+  angleAdvices,
+  configFileName
 }: {
   simulatorData: { position_pri: number; angle_pri: number }
   simulationRunning: boolean
@@ -17,11 +18,13 @@ export function ScenarioLogger({
     maxAngle: number
     type: 'advice' | 'caution'
   }[]
+  configFileName: string
 }) {
   const [isLogging, setIsLogging] = useState(false)
-
+  const [scenarioId, setScenarioId] = useState<string | null>(null)
   const [logData, setLogData] = useState<
     {
+      scenarioId: string
       timestamp: string
       thrust: number
       azimuthAngle: number
@@ -29,6 +32,7 @@ export function ScenarioLogger({
       exitTime?: number | null
       alertType?: 'advice' | 'caution' | null
       alertCategory?: 'thrust' | 'angle' // Marks if entry is thrust or angle
+      configFileName: string
     }[]
   >([])
 
@@ -66,8 +70,13 @@ export function ScenarioLogger({
       console.warn('Cannot start logging when simulation is not running.')
       return
     }
+
+    const newScenarioId = new Date().toISOString()
+
+    setScenarioId(newScenarioId)
     setIsLogging(true)
     setLogData([])
+
     console.log(`Started logging scenario ${scenarioCount}`)
   }
 
@@ -182,6 +191,8 @@ export function ScenarioLogger({
       setLogData((prevData) => [
         ...prevData,
         {
+          scenarioId: scenarioId ?? '0',
+          configFileName: configFileName,
           timestamp: currentTime,
           thrust: simulatorData.position_pri,
           azimuthAngle: simulatorData.angle_pri,
@@ -215,6 +226,8 @@ export function ScenarioLogger({
       setLogData((prevData) => [
         ...prevData,
         {
+          scenarioId: scenarioId ?? '0',
+          configFileName: configFileName,
           timestamp: currentTime,
           thrust: simulatorData.position_pri,
           azimuthAngle: simulatorData.angle_pri,
@@ -231,7 +244,14 @@ export function ScenarioLogger({
       lastAlertTime.current.angle = null
       firstResponseTime.current.angle = null
     }
-  }, [simulatorData, isLogging, thrustAdvices, angleAdvices])
+  }, [
+    simulatorData,
+    isLogging,
+    thrustAdvices,
+    angleAdvices,
+    configFileName,
+    scenarioId
+  ])
 
   // Automatically stop logging when simulation stops
   useEffect(() => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -25,7 +25,8 @@ import { SetpointSliders } from '../components/SetpointSliders'
 type LocationState = {
   angleAdvices?: AngleAdvice[]
   thrustAdvices?: LinearAdvice[]
-  alertConfig?: AlertConfig
+  alertConfig?: AlertConfig //TODO could write this into a csv by passing it to ScenarioLogger if necessary
+  selectedConfig: string
 }
 
 export function Dashboard() {
@@ -80,6 +81,8 @@ export function Dashboard() {
   // Alert zones
   const location = useLocation()
   const state = location.state as LocationState | null // Type casting for safety
+
+  const configFileName = state?.selectedConfig ?? 'unknown'
 
   // Fetch advices from location state (set in startup page) or use default values
   const angleAdvices: AngleAdvice[] = useMemo(
@@ -350,6 +353,7 @@ export function Dashboard() {
               position_pri: azimuthData.position_pri,
               angle_pri: azimuthData.angle_pri
             }}
+            configFileName={configFileName}
             thrustAdvices={thrustAdvices}
             angleAdvices={angleAdvices}
             simulationRunning={simulationRunning}

--- a/frontend/src/pages/Startup.tsx
+++ b/frontend/src/pages/Startup.tsx
@@ -89,7 +89,7 @@ export function Startup() {
 
   const [thrustAdvices, setThrustAdvices] = useState<LinearAdvice[]>([
     { min: 20, max: 50, type: AdviceType.advice, hinted: true },
-    { min: 60, max: 100, type: AdviceType.caution, hinted: true }
+    { min: 80, max: 100, type: AdviceType.caution, hinted: true }
   ])
 
   const updateAngleAdvice = <K extends keyof AngleAdvice>(
@@ -145,7 +145,12 @@ export function Startup() {
       sendToSimulator(JSON.stringify({ command: 'start_simulation' }))
       // Pass alert zones via navigation state
       await navigate('/simulator', {
-        state: { angleAdvices, thrustAdvices, alertConfig }
+        state: {
+          angleAdvices,
+          thrustAdvices,
+          alertConfig,
+          selectedConfig
+        }
       })
     } catch (error) {
       console.error('Failed to start simulation:', error)


### PR DESCRIPTION
The scenarioId is set when logging begins. The config file name  is propped down from the startup page to the dashboard to the scenario logger.

- The scenario ID is a timestamp that uniquely identifies when the scenario starts.
- Instead of passing scenarioId as a prop, we generate and store it when the scenario starts.
- We persist the same scenarioId across all logs
- The selectedConfig is propped from Startup.tsx -> Dashboard.tsx -> ScenarioLogger.tsx

A thought i had along the way:
- This change causes 100% duplicates for all logs in a scenario for these two columns. Perhaps they should be used to create the name for the log instead?

Final solution: 
- Decided to remove both columns from the log, and rather to use them as the name (unique) for the csv file. Thus, the csv file is now named "scenarioId + "-" + "configFileName"


