### PR TITLE
72 refactoring startup page and experiment logic

### DIFF
--- a/backend/infrastructure/controller/azimuth_controller.py
+++ b/backend/infrastructure/controller/azimuth_controller.py
@@ -269,7 +269,7 @@ class AzimuthController:
             return False
         
         
-    async def set_detent(self, detent: int, type: int, pos1: int, pos2: int,):
+    async def set_detent(self, detent: int, type: int, pos: int):
         """
         Writes the detent value to the Modbus register.
 
@@ -294,10 +294,8 @@ class AzimuthController:
             if (type == "thrust"):
                 logger.info("Trying to set detents for thruster")
                 # The positioning of the detents
-                await self.client.write_register(address=thrust_hreg_pos1, value=pos1, slave=self.slave_id)
-                logger.info("Detent has been set (i think) for thruster pos1")
-                await self.client.write_register(address=thrust_hreg_pos2, value=pos2, slave=self.slave_id)
-                logger.info("Detent has been set (i think) for thruster pos2")
+                await self.client.write_register(address=thrust_hreg_pos1, value=pos, slave=self.slave_id)
+                logger.info("Detent has been setfor thruster pos")
 
                 # The strength of the detents
                 await self.client.write_register(address=strength_thrust_hreg, value=detent, slave=self.slave_id)
@@ -306,10 +304,8 @@ class AzimuthController:
                 return True
             if (type == "angle"):
                 # The positioning of the detents
-                await self.client.write_register(address=angle_hreg_pos1, value=pos1, slave=self.slave_id)
-                logger.info("Detent has been set (i think) for angle pos1")
-                await self.client.write_register(address=angle_hreg_pos2, value=pos2, slave=self.slave_id)
-                logger.info("Detent has been set (i think) for angle pos2")
+                await self.client.write_register(address=angle_hreg_pos1, value=pos, slave=self.slave_id)
+                logger.info("Detent has been set for angle pos")
 
                 # The strength of the detents
                 await self.client.write_register(address=strength_angle_hreg, value=detent, slave=self.slave_id)

--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -100,11 +100,10 @@ class Dashboard:
                 logger.info("Detent update request received.")
                 detent = data.get("detent", 0)
                 type = data.get("type", 0)
-                pos1 = data.get("pos1", 0)
-                pos2 = data.get("pos2", 0)
+                pos = data.get("pos", 0)
                 logger.info(f"Setting detent to {detent}")
 
-                success = await self.controller.set_detent(detent, type, pos1, pos2)
+                success = await self.controller.set_detent(detent, type, pos)
                 if success:
                     logger.info("Detent successfully updated.")
                 else:

--- a/frontend/src/hooks/useDetentFeedback.ts
+++ b/frontend/src/hooks/useDetentFeedback.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react'
+import { AdviceType, AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
+import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
+import { DashboardData } from '../types/DashboardData'
+import { AlertConfig } from '../types/AlertConfig'
+
+type UseDetentFeedbackProps = {
+  azimuthData: DashboardData
+  angleAdvices: AngleAdvice[]
+  thrustAdvices: LinearAdvice[]
+  alertConfig: AlertConfig
+  sendToBackend: (data: unknown) => void
+}
+
+export function useDetentFeedback({
+  azimuthData,
+  angleAdvices,
+  thrustAdvices,
+  alertConfig,
+  sendToBackend
+}: UseDetentFeedbackProps) {
+  const detentsSentRef = useRef(false)
+
+  useEffect(() => {
+    if (
+      !alertConfig.enableDetents ||
+      detentsSentRef.current ||
+      azimuthData.position_pri === 0
+    )
+      return
+
+    // ANGLE ADVICE: center-based detent
+    for (const advice of angleAdvices) {
+      if (advice.type === AdviceType.advice) {
+        const center = (advice.minAngle + advice.maxAngle) / 2
+        sendToBackend({
+          command: 'set_detent',
+          type: 'angle',
+          pos1: center,
+          pos2: center,
+          detent: 1
+        })
+      }
+    }
+
+    // THRUST ADVICE: center-based detent
+    for (const advice of thrustAdvices) {
+      if (advice.type === AdviceType.advice) {
+        const center = (advice.min + advice.max) / 2
+        sendToBackend({
+          command: 'set_detent',
+          type: 'thrust',
+          pos1: center,
+          pos2: center,
+          detent: 1
+        })
+      }
+    }
+
+    detentsSentRef.current = true
+  }, [
+    azimuthData,
+    angleAdvices,
+    thrustAdvices,
+    alertConfig.enableDetents,
+    sendToBackend
+  ])
+}

--- a/frontend/src/hooks/useDetentFeedback.ts
+++ b/frontend/src/hooks/useDetentFeedback.ts
@@ -36,8 +36,7 @@ export function useDetentFeedback({
         sendToBackend({
           command: 'set_detent',
           type: 'angle',
-          pos1: center,
-          pos2: center,
+          pos: center,
           detent: 1
         })
       }
@@ -50,8 +49,7 @@ export function useDetentFeedback({
         sendToBackend({
           command: 'set_detent',
           type: 'thrust',
-          pos1: center,
-          pos2: center,
+          pos: center,
           detent: 1
         })
       }

--- a/frontend/src/hooks/useFrictionFeedback.ts
+++ b/frontend/src/hooks/useFrictionFeedback.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react'
+import { AdviceType, AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
+import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
+import { DashboardData } from '../types/DashboardData'
+import { AlertConfig } from '../types/AlertConfig'
+
+type UseFrictionFeedbackParams = {
+  azimuthData: DashboardData
+  angleAdvices: AngleAdvice[]
+  thrustAdvices: LinearAdvice[]
+  sendToBackend: (data: unknown) => void
+  alertConfig: AlertConfig
+}
+
+export function useFrictionFeedback({
+  azimuthData,
+  angleAdvices,
+  thrustAdvices,
+  sendToBackend,
+  alertConfig
+}: UseFrictionFeedbackParams) {
+  const inThrustAdviceZoneRef = useRef(false)
+  const inAngleAdviceZoneRef = useRef(false)
+
+  useEffect(() => {
+    if (!azimuthData) return
+
+    let inThrustAdvice = false
+    let inAngleAdvice = false
+
+    // Check thrust advice
+    for (const advice of thrustAdvices) {
+      if (
+        advice.type === AdviceType.advice &&
+        azimuthData.position_pri >= advice.min &&
+        azimuthData.position_pri <= advice.max
+      ) {
+        inThrustAdvice = true
+      }
+    }
+
+    // Check angle advice
+    for (const advice of angleAdvices) {
+      if (
+        advice.type === AdviceType.advice &&
+        azimuthData.position_sec >= advice.minAngle &&
+        azimuthData.position_sec <= advice.maxAngle
+      ) {
+        inAngleAdvice = true
+        break
+      }
+    }
+
+    const frictionInside = alertConfig.adviceHighResistance ? 3 : 1
+    const frictionOutside = alertConfig.regularHighResistance ? 3 : 1
+
+    // THRUST ENTRY
+    if (inThrustAdvice && !inThrustAdviceZoneRef.current) {
+      console.log('Entered THRUST advice zone')
+      sendToBackend({
+        command: 'set_friction_strength',
+        friction: frictionInside
+      })
+      inThrustAdviceZoneRef.current = true
+    }
+
+    // THRUST EXIT
+    if (!inThrustAdvice && inThrustAdviceZoneRef.current) {
+      console.log('Exited THRUST advice zone')
+      sendToBackend({
+        command: 'set_friction_strength',
+        friction: frictionOutside
+      })
+      inThrustAdviceZoneRef.current = false
+    }
+
+    // ANGLE ENTRY
+    if (inAngleAdvice && !inAngleAdviceZoneRef.current) {
+      console.log('Entered ANGLE advice zone')
+      sendToBackend({
+        command: 'set_friction_strength',
+        friction: frictionInside
+      })
+      inAngleAdviceZoneRef.current = true
+    }
+
+    // ANGLE EXIT
+    if (!inAngleAdvice && inAngleAdviceZoneRef.current) {
+      console.log('Exited ANGLE advice zone')
+      sendToBackend({
+        command: 'set_friction_strength',
+        friction: frictionOutside
+      })
+      inAngleAdviceZoneRef.current = false
+    }
+  }, [
+    azimuthData,
+    angleAdvices,
+    thrustAdvices,
+    sendToBackend,
+    alertConfig.adviceHighResistance,
+    alertConfig.regularHighResistance
+  ])
+}

--- a/frontend/src/hooks/useVibrationFeedback.ts
+++ b/frontend/src/hooks/useVibrationFeedback.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { AdviceType, AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
+import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
+import { DashboardData } from '../types/DashboardData'
+import { AlertConfig } from '../types/AlertConfig'
+
+type UseVibrationFeedbackProps = {
+  azimuthData: DashboardData
+  angleAdvices: AngleAdvice[]
+  thrustAdvices: LinearAdvice[]
+  alertConfig: AlertConfig
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sendToBackend: (message: any) => void
+}
+
+export function useVibrationFeedback({
+  azimuthData,
+  angleAdvices,
+  thrustAdvices,
+  alertConfig,
+  sendToBackend
+}: UseVibrationFeedbackProps) {
+  const lastSentVibration = useRef<number>(0)
+
+  const getVibrationStrength = useCallback(() => {
+    let strength = 0
+    let type: AdviceType | null = null
+
+    // Check thruster caution zone
+    for (const advice of thrustAdvices) {
+      if (
+        azimuthData.position_pri >= advice.min &&
+        azimuthData.position_pri <= advice.max &&
+        advice.type === AdviceType.caution
+      ) {
+        type = AdviceType.caution
+        strength = alertConfig.vibrationStrengthThruster ?? 1
+      }
+    }
+
+    // Check angle caution zone
+    for (const advice of angleAdvices) {
+      if (
+        azimuthData.position_sec >= advice.minAngle &&
+        azimuthData.position_sec <= advice.maxAngle &&
+        advice.type === AdviceType.caution
+      ) {
+        type =  AdviceType.caution
+        strength = Math.max(strength, alertConfig.vibrationStrengthAngle ?? 1)
+      }
+    }
+
+    return [strength, type]
+  }, [
+    angleAdvices,
+    thrustAdvices,
+    azimuthData.position_pri,
+    azimuthData.position_sec,
+    alertConfig.vibrationStrengthThruster,
+    alertConfig.vibrationStrengthAngle
+  ])
+
+  useEffect(() => {
+    if (!azimuthData) return
+
+    const vibrationStrength = getVibrationStrength()[0]
+    if (
+      vibrationStrength !== lastSentVibration.current &&
+      alertConfig.enableVibration
+    ) {
+      sendToBackend({
+        command: 'set_vibration',
+        strength: vibrationStrength
+      })
+
+      if (typeof vibrationStrength === 'number') {
+        lastSentVibration.current = vibrationStrength
+      }
+    }
+  }, [
+    azimuthData,
+    getVibrationStrength,
+    sendToBackend,
+    alertConfig.enableVibration
+  ])
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import { AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
 import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
-//import { AdviceType } from '@oicl/openbridge-webcomponents/src/navigation-instruments/watch/advice'
 import { AzimuthThruster } from '../components/AzimuthThruster'
 import { Compass } from '../components/Compass'
 import { InstrumentField } from '../components/InstrumentField'
@@ -43,8 +42,6 @@ export function Dashboard() {
   const [alertTime, setAlertTime] = useState<number | null>(null)
   const [, setAlertType] = useState<'advice' | 'caution' | null>(null)
   const navigate = useNavigate()
-
-  //const lastSentVibration = useRef<number>(0)
 
   // Keep track of last sent command
   const lastSentCommand = useRef<{ position: number; angle: number } | null>(
@@ -123,8 +120,6 @@ export function Dashboard() {
       } as AlertConfig),
     [state?.alertConfig]
   )
-
-  //const detentsSentRef = useRef(false)
 
   useEffect(() => {
     if (azimuthData) {

--- a/frontend/src/pages/Startup.tsx
+++ b/frontend/src/pages/Startup.tsx
@@ -27,7 +27,9 @@ export function Startup() {
     enableVibration: true,
     enableDetents: true,
     adviceHighResistance: true,
-    regularHighResistance: false
+    regularHighResistance: false,
+    vibrationStrengthThruster: 1,
+    vibrationStrengthAngle: 1
   })
 
   const initialSimData: SimulatorData = {
@@ -294,6 +296,58 @@ export function Startup() {
               }
             />
           </div>
+          {alertConfig.enableVibration && (
+            <>
+              <div className="label-container">
+                <div className="label-wrapper">
+                  <span
+                    className="info-icon"
+                    data-tooltip="Set vibration strength for thruster caution zones"
+                  >
+                    ℹ
+                  </span>
+                  <label>Thruster Caution Vibration Strength</label>
+                </div>
+                <input
+                  type="number"
+                  min={1}
+                  max={3}
+                  value={alertConfig.vibrationStrengthThruster ?? 1}
+                  onChange={(e) =>
+                    setAlertConfig((prev) => ({
+                      ...prev,
+                      vibrationStrengthThruster: Number(e.target.value)
+                    }))
+                  }
+                />
+              </div>
+
+              <div className="label-container">
+                <div className="label-wrapper">
+                  <span
+                    className="info-icon"
+                    data-tooltip="Set vibration strength for angle caution zones"
+                  >
+                    ℹ
+                  </span>
+                  <label>Angle Caution Vibration Strength</label>
+                </div>
+                <input
+                  type="number"
+                  min={1}
+                  max={3}
+                  value={alertConfig.vibrationStrengthAngle ?? 1}
+                  onChange={(e) =>
+                    setAlertConfig((prev) => ({
+                      ...prev,
+                      vibrationStrengthAngle: Number(e.target.value)
+                    }))
+                  }
+                />
+              </div>
+            </>
+          )}
+
           <div className="label-container">
             <div className="label-wrapper">
               <span className="info-icon" data-tooltip="Enable detent feedback">

--- a/frontend/src/pages/Startup.tsx
+++ b/frontend/src/pages/Startup.tsx
@@ -25,7 +25,9 @@ export function Startup() {
   const [alertConfig, setAlertConfig] = useState<AlertConfig>({
     vibrationEnter: 1,
     enableVibration: true,
-    enableDetents: true
+    enableDetents: true,
+    adviceHighResistance: true,
+    regularHighResistance: false
   })
 
   const initialSimData: SimulatorData = {
@@ -306,6 +308,51 @@ export function Startup() {
                 setAlertConfig((prev) => ({
                   ...prev,
                   enableDetents: !prev.enableDetents
+                }))
+              }
+            />
+          </div>
+          {/* Toggle for High Resistance Inside Advice Zones */}
+          <div className="label-container">
+            <div className="label-wrapper">
+              <span
+                className="info-icon"
+                data-tooltip="Sets high resistance inside advice zones"
+              >
+                ℹ
+              </span>
+              <label>High Resistance Inside Advice Zones</label>
+            </div>
+            <input
+              type="checkbox"
+              checked={alertConfig.adviceHighResistance}
+              onChange={() =>
+                setAlertConfig((prev) => ({
+                  ...prev,
+                  adviceHighResistance: !prev.adviceHighResistance
+                }))
+              }
+            />
+          </div>
+
+          {/* Toggle for High Resistance Outside Advice Zones */}
+          <div className="label-container">
+            <div className="label-wrapper">
+              <span
+                className="info-icon"
+                data-tooltip="Sets high resistance outside advice zones"
+              >
+                ℹ
+              </span>
+              <label>High Resistance Outside Advice Zones</label>
+            </div>
+            <input
+              type="checkbox"
+              checked={alertConfig.regularHighResistance}
+              onChange={() =>
+                setAlertConfig((prev) => ({
+                  ...prev,
+                  regularHighResistance: !prev.regularHighResistance
                 }))
               }
             />

--- a/frontend/src/types/AlertConfig.ts
+++ b/frontend/src/types/AlertConfig.ts
@@ -2,4 +2,6 @@ export type AlertConfig = {
     vibrationEnter: number
     enableVibration: boolean
     enableDetents: boolean
+    adviceHighResistance: boolean,
+    regularHighResistance: boolean,
   }

--- a/frontend/src/types/AlertConfig.ts
+++ b/frontend/src/types/AlertConfig.ts
@@ -4,4 +4,6 @@ export type AlertConfig = {
     enableDetents: boolean
     adviceHighResistance: boolean,
     regularHighResistance: boolean,
+    vibrationStrengthThruster: number;
+    vibrationStrengthAngle: number;
   }


### PR DESCRIPTION
This PR implements improvements and refactoring, focusing on vibration, detent and friction feedback systems. The goal was to modularize logic, improve configurability, and enhance usability for moderators. 

**Friction Feedback**
- Added two new toggles in the Startup page “High Resistance Inside Advice Zones” and “High Resistance Outside Advice Zones”.
- The new values are passed via alertConfig to the simulator.
- Created a new hook called useFrictionFeedback
  - Dynamically applies different friction levels based on whether the operator is inside or outside an advice zone.
  - Supports both thrust and angle zones.
  - Sends appropriate backend commands only when zone transitions occur.

**Vibration Feedback**
- Added new UI controls in the Startup page for:
  - "Enable Vibration" toggle (which is just a checkbox as of now)
  - Separate input fields for setting vibration strength (1–3) for thruster and angle caution zones
- Extracted vibration feedback logic into a new custom hook called useVibrationFeedback
- Dynamically determines vibration strength based on zone type and control type (angle or thrust)
- Sends vibration feedback only on state change

**Detent Feedback**
- Created a new custom hook called useDetentFeedback
- Replaces dual detent logic with a single detent placed at the center of each advice zone (makes it more intuitive that the optimal spot has been reached)
- Supports both angle and thrust advice zones
- Triggered once per simulation run to avoid duplicate commands
- Removed the old inline detent-setting logic from Dashboard.tsx

**Cleanup**
- Removed the now-unnecessary getVibrationStrength() function from Dashboard.tsx
- Improved separation of concerns by moving much of the feedback logic into reusable hooks
- Ensured all feedback systems are driven by the alertConfig passed from the startup page

