### PR TITLE
77 simulator keeps making right turns

### DIFF
--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -25,12 +25,12 @@ class Dashboard:
         """Assigns a database instance to the dashboard singleton."""
         self.database = database
         
-        
-        
-    """
     async def fetch_data(self):
         while True:
             try:
+                if not self.controller.client or not self.controller.client.connected:
+                    await asyncio.sleep(0.1)
+                    continue  # Try again on next loop
                 raw_data = await self.controller.fetch_dashboard_data()  #await self.controller.get_latest_data() # await self.controller.fetch_dashboard_data()
                 formatted_data = self.format_data(raw_data)
                 
@@ -42,27 +42,8 @@ class Dashboard:
                 logger.error(f"Error fetching register data: {e}")
 
             await asyncio.sleep(0.1)  # Ensures it doesn't flood the system
-    """
     
-    async def fetch_data(self):
-        while True:
-            try:
-                # Skip fetch if controller isn't ready
-                if not self.controller.client or not self.controller.client.connected:
-                    await asyncio.sleep(0.1)
-                    continue  # Try again on next loop
-
-                raw_data = await self.controller.fetch_dashboard_data()
-                formatted_data = self.format_data(raw_data)
-
-                if formatted_data and formatted_data != self.latest_data and self.clients:
-                    self.latest_data = formatted_data
-
-            except Exception as e:
-                logger.error(f"Error fetching register data: {e}")
-
-            await asyncio.sleep(0.1)  # Prevents tight loop
-
+ 
     async def handle_client_messages(self, websocket: WebSocket, message: str):
         """Handles incoming WebSocket messages and processes commands."""
         try:
@@ -208,4 +189,3 @@ def start_dashboard():
 async def websocket_endpoint(websocket: WebSocket):
     await dashboard.websocket_endpoint(websocket)
     
-

--- a/frontend/src/components/ScenarioLogger.tsx
+++ b/frontend/src/components/ScenarioLogger.tsx
@@ -10,7 +10,7 @@ export function ScenarioLogger({
   angleAdvices,
   configFileName
 }: {
-  simulatorData: { position_pri: number; angle_pri: number }
+  simulatorData: { thrust: number; angle: number }
   simulationRunning: boolean
   thrustAdvices: { min: number; max: number; type: 'advice' | 'caution' }[]
   angleAdvices: {
@@ -113,8 +113,8 @@ export function ScenarioLogger({
 
     for (const advice of thrustAdvices) {
       if (
-        simulatorData.position_pri >= advice.min &&
-        simulatorData.position_pri <= advice.max
+        simulatorData.thrust >= advice.min &&
+        simulatorData.thrust <= advice.max
       ) {
         thrustAlertNow = true
         detectedThrustType = advice.type
@@ -123,8 +123,8 @@ export function ScenarioLogger({
 
     for (const advice of angleAdvices) {
       if (
-        simulatorData.angle_pri >= advice.minAngle &&
-        simulatorData.angle_pri <= advice.maxAngle
+        simulatorData.angle >= advice.minAngle &&
+        simulatorData.angle <= advice.maxAngle
       ) {
         angleAlertNow = true
         detectedAngleType = advice.type
@@ -182,8 +182,8 @@ export function ScenarioLogger({
       alertActive.current.thrust &&
       !thrustAdvices.some(
         (advice) =>
-          simulatorData.position_pri >= advice.min &&
-          simulatorData.position_pri <= advice.max
+          simulatorData.thrust >= advice.min &&
+          simulatorData.thrust <= advice.max
       )
     ) {
       console.log('Exiting thrust alert zone')
@@ -195,8 +195,8 @@ export function ScenarioLogger({
         ...prevData,
         {
           timestamp: currentTime,
-          thrust: simulatorData.position_pri,
-          azimuthAngle: simulatorData.angle_pri,
+          thrust: simulatorData.thrust,
+          azimuthAngle: simulatorData.angle,
           reactionTime: firstResponseTime.current.thrust
             ? firstResponseTime.current.thrust -
               (lastAlertTime.current.thrust ?? 0)
@@ -216,8 +216,8 @@ export function ScenarioLogger({
       alertActive.current.angle &&
       !angleAdvices.some(
         (advice) =>
-          simulatorData.angle_pri >= advice.minAngle &&
-          simulatorData.angle_pri <= advice.maxAngle
+          simulatorData.angle >= advice.minAngle &&
+          simulatorData.angle <= advice.maxAngle
       )
     ) {
       console.log('Exiting angle alert zone')
@@ -229,8 +229,8 @@ export function ScenarioLogger({
         ...prevData,
         {
           timestamp: currentTime,
-          thrust: simulatorData.position_pri,
-          azimuthAngle: simulatorData.angle_pri,
+          thrust: simulatorData.thrust,
+          azimuthAngle: simulatorData.angle,
           reactionTime: firstResponseTime.current.angle
             ? firstResponseTime.current.angle -
               (lastAlertTime.current.angle ?? 0)

--- a/frontend/src/pages/MiniDashboard.tsx
+++ b/frontend/src/pages/MiniDashboard.tsx
@@ -11,9 +11,7 @@ import { DashboardData } from '../types/DashboardData'
 export function MiniDashboard() {
   const initialData: DashboardData = {
     position_pri: 0,
-    angle_pri: 0,
     position_sec: 0,
-    angle_sec: 0,
     pos_setpoint_pri: 0,
     pos_setpoint_sec: 0
   }
@@ -26,10 +24,9 @@ export function MiniDashboard() {
         <TabPanel>
           <MemoizedAzimuthThruster
             thrust={data.data.position_pri}
-            angle={data.data.angle_pri}
+            angle={data.data.position_sec}
             angleSetpoint={0}
             thrustSetPoint={0}
-            onSetPointChange={() => {}} // Dummy function
             touching={true}
             atThrustSetpoint={false}
             atAngleSetpoint={false}
@@ -38,7 +35,7 @@ export function MiniDashboard() {
           />
         </TabPanel>
         <TabPanel>
-          <MemoizedRudder angle={data.data.angle_pri} />
+          <MemoizedRudder angle={data.data.position_sec} />
         </TabPanel>
         <TabPanel>
           <MemoizedThruster thrust={data.data.position_pri} />

--- a/frontend/src/types/DashboardData.ts
+++ b/frontend/src/types/DashboardData.ts
@@ -1,8 +1,6 @@
 export type DashboardData = {
   position_pri: number
   position_sec: number
-  angle_pri: number
-  angle_sec: number
   pos_setpoint_pri: number
   pos_setpoint_sec: number
 }
@@ -18,5 +16,5 @@ export type SimulatorData = {
   consumedTotal: number
   checkpoints: number
   angle: number
-  power: number
+  thrust: number
 }


### PR DESCRIPTION
This PR includes backend fixes, frontend consistency, and key adjustments to the ship simulator for more realistic behavior and better system stability.

**Backend and webSocket updates**
- Ensured Modbus controller connects reliably via start_services().
- Improved logging for better observability of controller values (thrust/angle).
- Cleaned up parameter naming for clarity across the stack (position → thrust, angle remains consistent).
- Addressed inconsistent register fetches by skipping fetches if the controller is disconnected.

**Simulator enhancements**
- Normalized azimuth angle to a ±180° rudder range using:
```
function normalizeAzimuthAngle(angle) {
  let normalized = angle % 360;
  if (normalized > 180) normalized -= 360;
  return normalized;
}
```

- Replaced direct rudder assignment with normalized rudder angle for more accurate heading behavior:
`manoeuvringMovement.states.rudderAngle = normalizeAzimuthAngle(message.angle);
`

- Smoothed out acceleration using:
`manoeuvringMovement.states.V.u += (speedFactor - manoeuvringMovement.states.V.u) * accelerationRate;
`

- Reduced ship turning rate and speed gain to achieve more realistic dynamics:
  - thrustEffect = 0.2
  - angleFactor = 0.03
  - accelerationRate = 0.3


