### PR TITLE
81 detent logic

### DIFF
--- a/backend/infrastructure/controller/azimuth_controller.py
+++ b/backend/infrastructure/controller/azimuth_controller.py
@@ -378,7 +378,8 @@ class AzimuthController:
                     logger.info(f"Boundary has been set for angle with address: {angle_boundary_lower} and {angle_boundary_upper}")
                     logger.info(f"and value: {lower} and {upper}")
                     # The strength of the boundary
-                    await self  
+                    await self.client.write_register(address=angle_boundary_strength, value=boundary, slave=self.slave_id)
+                    logger.info(f" Set angle boundary strength to {boundary} at register {angle_boundary_strength}")
             except ModbusIOException as e:
                 logger.error(f"[ERROR] Modbus IO Exception while writing boundary: {e}")
                 return False
@@ -420,6 +421,28 @@ class AzimuthController:
             print(f"[ERROR] Unexpected error while writing friction: {e}")
             return False
         
+        
+    async def clear_haptics(self):
+        # Between each scenario, the haptics detent and boundary should be cleared
+        # This is done by setting the enable coil to False
+        enable_detents_reg = 1
+        
+        if not self.client or not self.client.connected:
+            print("[ERROR] Not connected to Modbus. Cannot set friction.")
+            return False
+
+        try:
+            await self.set_boundary(False, 0, 0, 0, 0)
+            await self.client.write_coil(address=enable_detents_reg, value=False, slave=self.slave_id)
+            
+            logger.info(f" Disabled detents at register {enable_detents_reg}")
+            
+        except ModbusIOException as e:
+            logger.error(f"[ERROR] Modbus IO Exception while clearing haptics: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"[ERROR] Unexpected error while clearing haptics: {e}")
+            return False
         
 
     async def get_latest_data(self):

--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -116,6 +116,10 @@ class Dashboard:
                     logger.info("Boundary successfully updated.")
                 else:
                     logger.error("Failed to update boundary.")
+                    
+            elif data["command"] == "clear_haptics":
+                logger.info("Received command: clear_haptics")
+                await controller.clear_haptics()
 
             # Handle stop simulation command
             if data.get("command") == "stop_simulation":

--- a/frontend/src/components/controlPanel/ScenarioControlPanel.tsx
+++ b/frontend/src/components/controlPanel/ScenarioControlPanel.tsx
@@ -32,7 +32,12 @@ export function ScenarioControlPanel({
         <label>Scenario</label>
         <select
           value={selectedScenario}
-          onChange={(e) => onScenarioChange(e.target.value as ScenarioKey)}
+          onChange={(e) => {
+            const newValue = e.target.value as ScenarioKey
+            if (newValue !== selectedScenario) {
+              onScenarioChange(newValue)
+            }
+          }}
         >
           {Object.entries(scenarioOptions).map(([key, label]) => (
             <option key={key} value={key}>

--- a/frontend/src/constants/scenarioOptions.ts
+++ b/frontend/src/constants/scenarioOptions.ts
@@ -4,5 +4,5 @@ export const scenarioOptions: Record<ScenarioKey, string> = {
     'maintain-speed': 'Maintain Speed',
     'turn-around': 'Turn Around',
     'navigate-buoys': 'Navigate Buoys',
-    'depart-harbor': 'Depart Harbor'
+    'depart-harbor': 'Depart Harbor',
   }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -136,15 +136,30 @@ export function Dashboard() {
     [state?.alertConfig]
   )
 
+  const previousScenario = useRef<ScenarioKey | null>(null)
+
   useEffect(() => {
+    if (previousScenario.current === selectedScenario) {
+      console.log(
+        `[Scenario] No change in scenario, skipping `,
+        selectedScenario
+      )
+      return
+    }
+
+    previousScenario.current = selectedScenario
+
+    console.log(`[Scenario] Switched to ${selectedScenario}, clearing haptics`)
+    sendToBackend({ command: 'clear_haptics' })
+
     const config = scenarioAdviceMap[selectedScenario]
     setAngleAdvices(config.angleAdvices)
     setThrustAdvices(config.thrustAdvices)
     if (config.boundaries) {
-      setBoundaryConfig(config.boundaries) // local state for useBoundaryFeedback
+      setBoundaryConfig(config.boundaries)
     }
-    setCurrentTask(1) // Reset task when switching scenario
-  }, [selectedScenario])
+    setCurrentTask(1)
+  }, [selectedScenario, sendToBackend])
 
   useEffect(() => {
     if (azimuthData) {


### PR DESCRIPTION
This PR ensures that all haptic feedback (currently detents and boundaries) is cleared before a new scenario begins. This prevents stale haptic states from previous experiments from interfering with the current test. All haptic feedback zones are now reliably reset before applying new scenarios. Verified by observing proper clearing on each switch and on experiment start.

**Improvements**:
- Introduced a new command clear_haptics sent to the backend that disables all active detents and boundaries
- Trigger clear_haptics on scenario switch using useEffect
- Ensures a clean slate before applying new scenario settings
- Protected against unnecessary re-runs of scenario logic using previousScenario ref
- Bugfix: Added await to backend clearing logic to ensure registers are fully reset before new ones are applied

**How it was tested:**
- Start any scenario and interact with detents/boundaries
- Switch to a new scenario without overlapping detents
- Confirm haptic feedback is clean (no leftover resistance/detents)
- Backend logs should show clear_haptics received before new zones are sent