### PR TITLE
83 logger selected scenario

### DIFF
--- a/frontend/src/components/ScenarioLogger.ts
+++ b/frontend/src/components/ScenarioLogger.ts
@@ -11,6 +11,7 @@ interface ScenarioLoggerProps {
   logData: LogEntry[]
   setLogData: (updater: (prev: LogEntry[]) => LogEntry[]) => void
   configFileName: string
+  selectedScenario: string
   thrustAdvices: {
     min: number
     max: number
@@ -30,7 +31,8 @@ export function ScenarioLogger({
   setLogData,
   configFileName,
   thrustAdvices,
-  angleAdvices
+  angleAdvices,
+  selectedScenario
 }: ScenarioLoggerProps) {
   const lastAlertTime = useRef<{ thrust: number | null; angle: number | null }>(
     {
@@ -148,7 +150,8 @@ export function ScenarioLogger({
           reactionTime,
           exitTime,
           alertType: alertTypeRef.current.thrust,
-          alertCategory: 'thrust'
+          alertCategory: 'thrust',
+          scenario: selectedScenario
         }
       ])
 
@@ -178,7 +181,8 @@ export function ScenarioLogger({
           reactionTime,
           exitTime,
           alertType: alertTypeRef.current.angle,
-          alertCategory: 'angle'
+          alertCategory: 'angle',
+          scenario: selectedScenario
         }
       ])
 

--- a/frontend/src/components/ScenarioLogger.ts
+++ b/frontend/src/components/ScenarioLogger.ts
@@ -3,10 +3,12 @@ import { LogEntry } from '../types/LogEntry'
 import { saveAs } from 'file-saver'
 import * as Papa from 'papaparse'
 import '../styles/dashboard.css'
+import { BoundaryConfig } from '../types/BoundaryConfig'
 
 interface ScenarioLoggerProps {
   simulatorData: { thrust: number; angle: number }
   simulationRunning: boolean
+  boundaryConfig: BoundaryConfig[]
   isLogging: boolean
   logData: LogEntry[]
   setLogData: (updater: (prev: LogEntry[]) => LogEntry[]) => void
@@ -32,6 +34,7 @@ export function ScenarioLogger({
   configFileName,
   thrustAdvices,
   angleAdvices,
+  boundaryConfig,
   selectedScenario
 }: ScenarioLoggerProps) {
   const lastAlertTime = useRef<{ thrust: number | null; angle: number | null }>(
@@ -62,7 +65,11 @@ export function ScenarioLogger({
     angle: null
   })
 
-  // ⏱ T1: Enter alert zone
+  const boundaryActive = useRef<boolean>(false)
+  const boundaryEnterTime = useRef<number | null>(null)
+
+
+  // T1: Enter alert zone
   useEffect(() => {
     if (!isLogging) return
 
@@ -104,9 +111,25 @@ export function ScenarioLogger({
       alertTypeRef.current.angle = angleType
       firstResponseTime.current.angle = null
     }
-  }, [simulatorData, thrustAdvices, angleAdvices, isLogging])
 
-  // ⏱ T2: Operator responds
+    const inBoundary = boundaryConfig.some((b) => {
+      if (!b.enabled) return false
+      if (b.type === 'thrust') {
+        return simulatorData.thrust >= b.lower && simulatorData.thrust <= b.upper
+      }
+      if (b.type === 'angle') {
+        return simulatorData.angle >= b.lower && simulatorData.angle <= b.upper
+      }
+      return false
+    })
+    
+    if (inBoundary && !boundaryActive.current) {
+      boundaryActive.current = true
+      boundaryEnterTime.current = Date.now()
+    }
+  }, [simulatorData, thrustAdvices, angleAdvices, isLogging, boundaryConfig])
+
+  // T2: Operator responds
   useEffect(() => {
     if (!isLogging) return
     const now = Date.now()
@@ -123,7 +146,7 @@ export function ScenarioLogger({
     }
   }, [simulatorData, isLogging])
 
-  // ⏱ T3: Exit alert zone
+  // T3: Exit alert zone
   useEffect(() => {
     if (!isLogging) return
 
@@ -189,7 +212,40 @@ export function ScenarioLogger({
       lastAlertTime.current.angle = null
       firstResponseTime.current.angle = null
     }
-  }, [simulatorData, isLogging, angleAdvices, thrustAdvices, setLogData, selectedScenario])
+    const stillInBoundary = boundaryConfig.some((b) => {
+      if (!b.enabled) return false
+      if (b.type === 'thrust') {
+        return simulatorData.thrust >= b.lower && simulatorData.thrust <= b.upper
+      }
+      if (b.type === 'angle') {
+        return simulatorData.angle >= b.lower && simulatorData.angle <= b.upper
+      }
+      return false
+    })
+    
+    if (boundaryActive.current && !stillInBoundary) {
+      boundaryActive.current = false
+    
+      const enter = boundaryEnterTime.current ?? 0
+      const exitTime = Date.now() - enter
+    
+      setLogData((prev) => [
+        ...prev,
+        {
+          timestamp: now,
+          thrust: simulatorData.thrust,
+          azimuthAngle: simulatorData.angle,
+          reactionTime: null,
+          exitTime,
+          alertType: 'boundary',
+          alertCategory: 'thrust',
+          scenario: selectedScenario
+        }
+      ])
+    
+      boundaryEnterTime.current = null
+    }
+  }, [simulatorData, isLogging, angleAdvices, thrustAdvices, setLogData, selectedScenario, boundaryConfig])
 
   // Export on stop
   useEffect(() => {

--- a/frontend/src/components/ScenarioLogger.ts
+++ b/frontend/src/components/ScenarioLogger.ts
@@ -189,7 +189,7 @@ export function ScenarioLogger({
       lastAlertTime.current.angle = null
       firstResponseTime.current.angle = null
     }
-  }, [simulatorData, isLogging, angleAdvices, thrustAdvices, setLogData])
+  }, [simulatorData, isLogging, angleAdvices, thrustAdvices, setLogData, selectedScenario])
 
   // Export on stop
   useEffect(() => {

--- a/frontend/src/hooks/useBoundaryFeedback.ts
+++ b/frontend/src/hooks/useBoundaryFeedback.ts
@@ -27,7 +27,6 @@ export function useBoundaryFeedback({ config, sendToBackend }: UseBoundaryFeedba
         upper: boundary.upper
       }
 
-      console.log('[Boundary] Sending boundary update:', command)
       sendToBackend(command)
     })
     sentRef.current = serialized

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -359,6 +359,7 @@ export function Dashboard() {
           logData={logData}
           setLogData={setLogData}
           isLogging={isLogging}
+          selectedScenario={selectedScenario}
         />
         {/*<TaskInstruction scenario={selectedScenario} taskNumber={currentTask} />*/}
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -139,13 +139,7 @@ export function Dashboard() {
   const previousScenario = useRef<ScenarioKey | null>(null)
 
   useEffect(() => {
-    if (previousScenario.current === selectedScenario) {
-      console.log(
-        `[Scenario] No change in scenario, skipping `,
-        selectedScenario
-      )
-      return
-    }
+    if (previousScenario.current === selectedScenario) return
 
     previousScenario.current = selectedScenario
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -354,6 +354,8 @@ export function Dashboard() {
           setLogData={setLogData}
           isLogging={isLogging}
           selectedScenario={selectedScenario}
+          boundaryConfig={boundaryConfig}
+
         />
         {/*<TaskInstruction scenario={selectedScenario} taskNumber={currentTask} />*/}
 

--- a/frontend/src/types/LogEntry.ts
+++ b/frontend/src/types/LogEntry.ts
@@ -6,4 +6,5 @@ export interface LogEntry {
     exitTime?: number | null;
     alertType?: 'advice' | 'caution' | null;
     alertCategory?: 'thrust' | 'angle';
+    scenario: string;
   }

--- a/frontend/src/types/LogEntry.ts
+++ b/frontend/src/types/LogEntry.ts
@@ -4,7 +4,7 @@ export interface LogEntry {
     azimuthAngle: number;
     reactionTime?: number | null;
     exitTime?: number | null;
-    alertType?: 'advice' | 'caution' | null;
+    alertType?: 'advice' | 'caution' | 'boundary' | null;
     alertCategory?: 'thrust' | 'angle';
     scenario: string;
   }

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -30,7 +30,8 @@ export const scenarioAdviceMap: Record<
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
-      { minAngle: 60, maxAngle: 240, type: AdviceType.caution, hinted: true }
+      { minAngle: 70, maxAngle: 180, type: AdviceType.caution, hinted: true },
+      { minAngle: -180, maxAngle: -70, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [{ min: 10, max: 30, type: AdviceType.advice, hinted: true }]
   },
@@ -39,7 +40,8 @@ export const scenarioAdviceMap: Record<
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
-      { minAngle: 60, maxAngle: 240, type: AdviceType.caution, hinted: true }
+      { minAngle: 70, maxAngle: 180, type: AdviceType.caution, hinted: true },
+      { minAngle: -180, maxAngle: -70, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [
       { min: 20, max: 60, type: AdviceType.advice, hinted: true },
@@ -64,7 +66,7 @@ export const scenarioAdviceMap: Record<
         enabled: true,
         boundary: 3,
         type: 'thrust',
-        lower: 0,
+        lower: 1,
         upper: 41
       }
     ]


### PR DESCRIPTION
This PR adds the currently selected scenario as a new column in the scenario logger CSV export. This ensures that each logged entry is clearly associated with the scenario under which it was generated.

- Updated LogEntry type to include a scenario field.
- Passed selectedScenario as a prop to the ScenarioLogger component.
- Included the scenario value in each log row added via setLogData.