### PR TITLE
86 detents able to turn them on and off for each scenario

### DIFF
--- a/backend/infrastructure/controller/azimuth_controller.py
+++ b/backend/infrastructure/controller/azimuth_controller.py
@@ -292,17 +292,26 @@ class AzimuthController:
             return False
         
         thrust_hreg_pos1 = 140
-        #thrust_hreg_pos2 = 141
+        thrust_hreg_pos2 = 141
         
         angle_hreg_pos1 = 240
-        #angle_hreg_pos2 = 241
+        angle_hreg_pos2 = 241
         
         strength_thrust_hreg = 100
         strength_angle_hreg = 200
         
         try:
-            # Enable detent everytime just in case
+            # Enable the use of detents
             await self.client.write_coil(address=1, value=True, slave=self.slave_id)
+            
+            # Enable only these detent registers
+            await self.client.write_coil(thrust_hreg_pos1, value=True, slave=self.slave_id)
+            await self.client.write_coil(angle_hreg_pos1, value=True, slave=self.slave_id)
+            
+            # Disable the other two detent registers
+            await self.client.write_coil(thrust_hreg_pos2, value=False, slave=self.slave_id)
+            await self.client.write_coil(angle_hreg_pos2, value=False, slave=self.slave_id)
+            
             if (type == "thrust"):
                 logger.info("Trying to set detents for thruster")
                 # The positioning of the detents
@@ -433,6 +442,8 @@ class AzimuthController:
 
         try:
             await self.set_boundary(False, 0, 0, 0, 0)
+            await self.client.write_register(address=140, value=0, slave=self.slave_id)
+            await self.client.write_register(address=240, value=0, slave=self.slave_id)
             await self.client.write_coil(address=enable_detents_reg, value=False, slave=self.slave_id)
             
             logger.info(f" Disabled detents at register {enable_detents_reg}")

--- a/backend/infrastructure/controller/azimuth_controller.py
+++ b/backend/infrastructure/controller/azimuth_controller.py
@@ -443,8 +443,13 @@ class AzimuthController:
         try:
             await self.set_boundary(False, 0, 0, 0, 0)
             await self.client.write_register(address=140, value=0, slave=self.slave_id)
+            await self.client.write_register(address=141, value=0, slave=self.slave_id)
             await self.client.write_register(address=240, value=0, slave=self.slave_id)
+            await self.client.write_register(address=241, value=0, slave=self.slave_id)
             await self.client.write_coil(address=enable_detents_reg, value=False, slave=self.slave_id)
+            await self.client.write_coil(address=40, value=False, slave=self.slave_id)
+            await self.client.write_coil(address=41, value=False, slave=self.slave_id)
+
             
             logger.info(f" Disabled detents at register {enable_detents_reg}")
             

--- a/frontend/src/hooks/useDetentFeedback.ts
+++ b/frontend/src/hooks/useDetentFeedback.ts
@@ -13,7 +13,7 @@ type UseDetentFeedbackProps = {
   thrustAdvices: LinearAdvice[]
   alertConfig: AlertConfig
   scenarioKey: string
-
+  detentEnabled: boolean
   sendToBackend: (data: unknown) => void
 }
 
@@ -24,7 +24,8 @@ export function useDetentFeedback({
   thrustAdvices,
   alertConfig,
   scenarioKey,
-  sendToBackend
+  sendToBackend,
+  detentEnabled
 }: UseDetentFeedbackProps) {
   const detentsSentRef = useRef(false)
 
@@ -35,7 +36,7 @@ export function useDetentFeedback({
   }, [angleAdvices, thrustAdvices, scenarioKey]) 
 
   useEffect(() => {
-    if (!alertConfig.enableDetents) return
+    if (!alertConfig.enableDetents || !detentEnabled) return
     if (detentsSentRef.current) return
     
     const angleReady = angle != null && !isNaN(angle)
@@ -77,5 +78,5 @@ export function useDetentFeedback({
     detentsSentRef.current = true
 
 
-  }, [thrust, angle, angleAdvices, thrustAdvices, alertConfig.enableDetents, sendToBackend])
+  }, [thrust, angle, angleAdvices, thrustAdvices, alertConfig.enableDetents, sendToBackend, detentEnabled])
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -242,7 +242,8 @@ export function Dashboard() {
     thrustAdvices,
     alertConfig,
     sendToBackend,
-    scenarioKey: selectedScenario
+    scenarioKey: selectedScenario,
+    detentEnabled: scenarioAdviceMap[selectedScenario]?.detent ?? false
   })
 
   useBoundaryFeedback({

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -9,6 +9,7 @@ import { BoundaryConfig } from '../types/BoundaryConfig'
 export const scenarioAdviceMap: Record<
   ScenarioKey,
   {
+    detent: boolean
     angleAdvices: AngleAdvice[]
     thrustAdvices: LinearAdvice[]
     boundaries?: BoundaryConfig[]
@@ -19,6 +20,7 @@ export const scenarioAdviceMap: Record<
   // Detent is at the end of the advice zone
   // Caution zone is right behind the advice zone
   'maintain-speed': {
+    detent: true,
     angleAdvices: [],
     thrustAdvices: [
       { min: 20, max: 50, type: AdviceType.advice, hinted: true },
@@ -27,6 +29,7 @@ export const scenarioAdviceMap: Record<
   },
   // The operator should turn the vessel around, but they should not turn around too quickly
   'turn-around': {
+    detent: true,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -37,6 +40,7 @@ export const scenarioAdviceMap: Record<
   },
   // The operator should aim to hit the buoys
   'navigate-buoys': {
+    detent: true,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -52,6 +56,7 @@ export const scenarioAdviceMap: Record<
   // After leaving the harbor, they should aim for 8 knots
   // Due to the speed limit, boundaries should be set at 4 knots
   'depart-harbor': {
+    detent: true,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },


### PR DESCRIPTION
This PR introduces improved control over detent activation based on the selected scenario.

- Added detent: boolean flag to ScenarioMap to specify whether detents should be enabled for each scenario.
- Updated useDetentFeedback to respect this flag and only send detents when detentEnabled is true.
- Ensured detents are properly reset and disabled when switching to a scenario that does not use detents.
- Refactored detent logic for better clarity and reliability.