### PR TITLE
88 changes as a result of the pilot test

### DIFF
--- a/backend/infrastructure/controller/azimuth_controller.py
+++ b/backend/infrastructure/controller/azimuth_controller.py
@@ -442,6 +442,7 @@ class AzimuthController:
 
         try:
             await self.set_boundary(False, 0, 0, 0, 0)
+            logger.info(f"Disabled boundary at register {enable_detents_reg}")
             await self.client.write_register(address=140, value=0, slave=self.slave_id)
             await self.client.write_register(address=141, value=0, slave=self.slave_id)
             await self.client.write_register(address=240, value=0, slave=self.slave_id)
@@ -449,6 +450,7 @@ class AzimuthController:
             await self.client.write_coil(address=enable_detents_reg, value=False, slave=self.slave_id)
             await self.client.write_coil(address=40, value=False, slave=self.slave_id)
             await self.client.write_coil(address=41, value=False, slave=self.slave_id)
+            logger.info(f"Disabled detents at register {enable_detents_reg}")
 
             
             logger.info(f" Disabled detents at register {enable_detents_reg}")

--- a/backend/infrastructure/websocket/dashboard.py
+++ b/backend/infrastructure/websocket/dashboard.py
@@ -79,14 +79,15 @@ class Dashboard:
                     logger.error("Failed to update vibration.")
                     
             # Handle detent updates
-            if data.get("command") == "set_detent":
+            if data.get("command") == "set_detents":
                 logger.info("Detent update request received.")
                 detent = data.get("detent", 0)
                 type = data.get("type", 0)
-                pos = data.get("pos", 0)
-                logger.info(f"Setting detent to {detent}")
+                #pos = data.get("pos", 0)
+                detents = data.get("detents", [])
+                logger.info(f"Setting detent for {type}")
 
-                success = await self.controller.set_detent(detent, type, pos)
+                success = await self.controller.set_detents(detent, type, detents)
                 if success:
                     logger.info("Detent successfully updated.")
                 else:

--- a/frontend/src/constants/scenarioOptions.ts
+++ b/frontend/src/constants/scenarioOptions.ts
@@ -1,8 +1,9 @@
-export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'navigate-buoys' | 'depart-harbor'
+export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'navigate-buoys' | 'depart-harbor' | 'scenario-5'
 
 export const scenarioOptions: Record<ScenarioKey, string> = {
     'maintain-speed': 'Maintain Speed',
     'turn-around': 'Turn Around',
     'navigate-buoys': 'Navigate Buoys',
     'depart-harbor': 'Depart Harbor',
+    'scenario-5': 'Scenario 5'
   }

--- a/frontend/src/constants/scenarioOptions.ts
+++ b/frontend/src/constants/scenarioOptions.ts
@@ -1,9 +1,16 @@
-export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'navigate-buoys' | 'depart-harbor' | 'scenario-5'
+export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'navigate-buoys' | 'depart-harbor' 
+| 'advice-detent-1' | 'advice-detent-2' | 'advice-detent-3' | 'caution-detent-1' | 
+'caution-detent-2' | 'caution-detent-3' 
 
 export const scenarioOptions: Record<ScenarioKey, string> = {
     'maintain-speed': 'Maintain Speed',
     'turn-around': 'Turn Around',
     'navigate-buoys': 'Navigate Buoys',
     'depart-harbor': 'Depart Harbor',
-    'scenario-5': 'Scenario 5'
+    'advice-detent-1': 'Advice Detent 1',
+    'advice-detent-2': 'Advice Detent 2',
+    'advice-detent-3': 'Advice Detent 3',
+    'caution-detent-1': 'Caution Detent 1',
+    'caution-detent-2': 'Caution Detent 2',
+    'caution-detent-3': 'Caution Detent 3'
   }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -243,8 +243,8 @@ export function Dashboard() {
     alertConfig,
     sendToBackend,
     scenarioKey: selectedScenario,
-    angleDetents: scenarioAdviceMap[selectedScenario]?.angleDetents,
-    thrustDetents: scenarioAdviceMap[selectedScenario]?.thrustDetents
+    angleDetentStrength: scenarioAdviceMap[selectedScenario].angleDetentStrength,
+    thrustDetentStrength: scenarioAdviceMap[selectedScenario].thrustDetentStrength
   })
 
   useBoundaryFeedback({

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -243,7 +243,8 @@ export function Dashboard() {
     alertConfig,
     sendToBackend,
     scenarioKey: selectedScenario,
-    detentEnabled: scenarioAdviceMap[selectedScenario]?.detent ?? false
+    angleDetents: scenarioAdviceMap[selectedScenario]?.angleDetents,
+    thrustDetents: scenarioAdviceMap[selectedScenario]?.thrustDetents
   })
 
   useBoundaryFeedback({

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -9,7 +9,14 @@ import { BoundaryConfig } from '../types/BoundaryConfig'
 export const scenarioAdviceMap: Record<
   ScenarioKey,
   {
-    detent: boolean
+    angleDetents: {
+      advice: number
+      caution: number
+    }
+    thrustDetents: {
+      advice: number
+      caution: number
+    }
     angleAdvices: AngleAdvice[]
     thrustAdvices: LinearAdvice[]
     boundaries?: BoundaryConfig[]
@@ -20,7 +27,14 @@ export const scenarioAdviceMap: Record<
   // Detent is at the end of the advice zone
   // Caution zone is right behind the advice zone
   'maintain-speed': {
-    detent: true,
+    angleDetents: {
+      advice: 0,
+      caution: 0
+    },
+    thrustDetents: {
+      advice: 2,
+      caution: 3
+    },
     angleAdvices: [],
     thrustAdvices: [
       { min: 20, max: 50, type: AdviceType.advice, hinted: true },
@@ -29,7 +43,14 @@ export const scenarioAdviceMap: Record<
   },
   // The operator should turn the vessel around, but they should not turn around too quickly
   'turn-around': {
-    detent: true,
+    angleDetents: {
+      advice: 1,
+      caution: 3
+    },
+    thrustDetents: {
+      advice: 1,
+      caution: 3
+    },
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -40,7 +61,14 @@ export const scenarioAdviceMap: Record<
   },
   // The operator should aim to hit the buoys
   'navigate-buoys': {
-    detent: true,
+    angleDetents: {
+      advice: 1,
+      caution: 3
+    },
+    thrustDetents: {
+      advice: 1,
+      caution: 3
+    },
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -56,7 +84,14 @@ export const scenarioAdviceMap: Record<
   // After leaving the harbor, they should aim for 8 knots
   // Due to the speed limit, boundaries should be set at 4 knots
   'depart-harbor': {
-    detent: true,
+    thrustDetents: {
+      advice: 1,
+      caution: 3
+    },
+    angleDetents: {
+      advice: 1,
+      caution: 3
+    },
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -74,6 +109,25 @@ export const scenarioAdviceMap: Record<
         lower: 1,
         upper: 41
       }
+    ]
+  },
+  'scenario-5': {
+    angleDetents: {
+      advice: 1, // soft detents for advice zones
+      caution: 3 // hard detents for caution zones
+    },
+    thrustDetents: {
+      advice: 1, // soft detents for advice zones
+      caution: 3 // hard detents for caution zones
+    },
+    angleAdvices: [
+      { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
+      { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
+      { minAngle: 60, maxAngle: 240, type: AdviceType.caution, hinted: true }
+    ],
+    thrustAdvices: [
+      { min: 0, max: 40, type: AdviceType.advice, hinted: true },
+      { min: 50, max: 100, type: AdviceType.caution, hinted: true }
     ]
   }
 }

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -9,14 +9,8 @@ import { BoundaryConfig } from '../types/BoundaryConfig'
 export const scenarioAdviceMap: Record<
   ScenarioKey,
   {
-    angleDetents: {
-      advice: number
-      caution: number
-    }
-    thrustDetents: {
-      advice: number
-      caution: number
-    }
+    angleDetentStrength: number
+    thrustDetentStrength: number
     angleAdvices: AngleAdvice[]
     thrustAdvices: LinearAdvice[]
     boundaries?: BoundaryConfig[]
@@ -27,14 +21,8 @@ export const scenarioAdviceMap: Record<
   // Detent is at the end of the advice zone
   // Caution zone is right behind the advice zone
   'maintain-speed': {
-    angleDetents: {
-      advice: 0,
-      caution: 0
-    },
-    thrustDetents: {
-      advice: 2,
-      caution: 3
-    },
+    angleDetentStrength: 0,
+    thrustDetentStrength: 1,
     angleAdvices: [],
     thrustAdvices: [
       { min: 20, max: 50, type: AdviceType.advice, hinted: true },
@@ -43,14 +31,8 @@ export const scenarioAdviceMap: Record<
   },
   // The operator should turn the vessel around, but they should not turn around too quickly
   'turn-around': {
-    angleDetents: {
-      advice: 1,
-      caution: 3
-    },
-    thrustDetents: {
-      advice: 1,
-      caution: 3
-    },
+    angleDetentStrength: 1,
+    thrustDetentStrength: 1,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -61,14 +43,8 @@ export const scenarioAdviceMap: Record<
   },
   // The operator should aim to hit the buoys
   'navigate-buoys': {
-    angleDetents: {
-      advice: 1,
-      caution: 3
-    },
-    thrustDetents: {
-      advice: 1,
-      caution: 3
-    },
+    angleDetentStrength: 1,
+    thrustDetentStrength: 1,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -84,14 +60,8 @@ export const scenarioAdviceMap: Record<
   // After leaving the harbor, they should aim for 8 knots
   // Due to the speed limit, boundaries should be set at 4 knots
   'depart-harbor': {
-    thrustDetents: {
-      advice: 1,
-      caution: 3
-    },
-    angleDetents: {
-      advice: 1,
-      caution: 3
-    },
+    angleDetentStrength: 1,
+    thrustDetentStrength: 1,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
@@ -111,22 +81,58 @@ export const scenarioAdviceMap: Record<
       }
     ]
   },
-  'scenario-5': {
-    angleDetents: {
-      advice: 1, // soft detents for advice zones
-      caution: 3 // hard detents for caution zones
-    },
-    thrustDetents: {
-      advice: 1, // soft detents for advice zones
-      caution: 3 // hard detents for caution zones
-    },
+  'advice-detent-1': {
+    angleDetentStrength: 1,
+    thrustDetentStrength: 1,
+    angleAdvices: [
+      { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true }
+    ],
+    thrustAdvices: [{ min: 30, max: 80, type: AdviceType.advice, hinted: true }]
+  },
+  'advice-detent-2': {
+    angleDetentStrength: 2,
+    thrustDetentStrength: 2,
+    angleAdvices: [
+      { minAngle: 30, maxAngle: 50, type: AdviceType.advice, hinted: true }
+    ],
+    thrustAdvices: [{ min: 10, max: 40, type: AdviceType.advice, hinted: true }]
+  },
+  'advice-detent-3': {
+    angleDetentStrength: 3,
+    thrustDetentStrength: 3,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
-      { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
-      { minAngle: 60, maxAngle: 240, type: AdviceType.caution, hinted: true }
+      { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true }
+    ],
+    thrustAdvices: [{ min: 0, max: 40, type: AdviceType.advice, hinted: true }]
+  },
+  'caution-detent-1': {
+    angleDetentStrength: 1,
+    thrustDetentStrength: 1,
+    angleAdvices: [
+      { minAngle: 60, maxAngle: 110, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [
-      { min: 0, max: 40, type: AdviceType.advice, hinted: true },
+      { min: 80, max: 100, type: AdviceType.caution, hinted: true }
+    ]
+  },
+  'caution-detent-2': {
+    angleDetentStrength: 2,
+    thrustDetentStrength: 2,
+    angleAdvices: [
+      { minAngle: 60, maxAngle: 120, type: AdviceType.caution, hinted: true }
+    ],
+    thrustAdvices: [
+      { min: 50, max: 100, type: AdviceType.caution, hinted: true }
+    ]
+  },
+  'caution-detent-3': {
+    angleDetentStrength: 3,
+    thrustDetentStrength: 3,
+    angleAdvices: [
+      { minAngle: 60, maxAngle: 130, type: AdviceType.caution, hinted: true }
+    ],
+    thrustAdvices: [
       { min: 50, max: 100, type: AdviceType.caution, hinted: true }
     ]
   }


### PR DESCRIPTION
The goal for this issue was to respond to the pilot test by doing these changes:
- Soft detents when entering an advice zone and soft detents when leaving it.
- Hard detents when entering a caution zone, and hard detents when leaving it.
- Make the detent a bit harder (level 2) for the thruster

This PR introduces a refactor of the detent feedback system to support per-scenario detent strength configuration for both angle and thrust axes. It includes improvements across the frontend, backend, and controller logic, with key changes to ensure compatibility with **Modbus limitations.**

**Frontend**:
- Refactored scenarioAdviceMap to use:
  - angleDetentStrength: number
  - thrustDetentStrength: number
- Updated the useDetentFeedback hook to:
  - Collect min and max values from all angleAdvices and thrustAdvices
  - Handle dynamic detent strength from scenario map
  - Send a single message per axis (angle/thrust) to the backend:

```{
      command: 'set_detents',
      type: 'angle' | 'thrust',
      detent: strength,
      detents: number[]
    }
```

**Backend**:
- Parses the new set_detents message format
- Passes detent strength and position list to controller class:
  - await self.controller.set_detents(detent_strength, type, detents)
- Refactored set_detents() to:
  - Cap at 2 detents per axis (due to hardware constraints) 
  - Write to angle_hreg_pos1/2 and thrust_hreg_pos1/2 manually using write_register()
  - Enable/disable the correct coils via write_coil() based on how many detents are used
  - Write detent strength to strength_angle_hreg / strength_thrust_hreg
  - Provide clear logging for every register written

Note: Because the modbus did not allow for more than one detent strength per axis (thrust and rudder), i had to make many new scenarios with 1 detent strength for each axis in order to incorporate the feedback from the pilot test (experiment with detent-strengths for advice and caution):
