### PR TITLE
93 new scenarios and bug fixes

### DIFF
--- a/frontend/src/components/ScenarioLogger.ts
+++ b/frontend/src/components/ScenarioLogger.ts
@@ -124,10 +124,28 @@ export function ScenarioLogger({
     })
     
     if (inBoundary && !boundaryActive.current) {
+      console.log('Boundary entered')
       boundaryActive.current = true
       boundaryEnterTime.current = Date.now()
+    
+      const now = new Date().toISOString()
+    
+      setLogData((prev) => [
+        ...prev,
+        {
+          timestamp: now,
+          thrust: simulatorData.thrust,
+          azimuthAngle: simulatorData.angle,
+          reactionTime: null,
+          exitTime: null,
+          alertType: 'boundary',
+          alertCategory: undefined,
+          scenario: selectedScenario
+        }
+      ])
     }
-  }, [simulatorData, thrustAdvices, angleAdvices, isLogging, boundaryConfig])
+    
+  }, [simulatorData, thrustAdvices, angleAdvices, isLogging, boundaryConfig, setLogData, selectedScenario])
 
   // T2: Operator responds
   useEffect(() => {

--- a/frontend/src/components/controlPanel/ScenarioControlPanel.tsx
+++ b/frontend/src/components/controlPanel/ScenarioControlPanel.tsx
@@ -15,8 +15,6 @@ interface ScenarioControlPanelProps {
 export function ScenarioControlPanel({
   selectedScenario,
   onScenarioChange,
-  showAzimuth,
-  toggleAzimuth,
   onStopSimulation,
   simulationRunning
 }: ScenarioControlPanelProps) {
@@ -39,10 +37,6 @@ export function ScenarioControlPanel({
             </option>
           ))}
         </select>
-
-        <button className="azimuth-button" onClick={toggleAzimuth}>
-          {showAzimuth ? 'Hide Azimuth' : 'Show Azimuth'}
-        </button>
         <button
           onClick={onStopSimulation}
           className={simulationRunning ? 'stop-button' : 'disabled-button'}

--- a/frontend/src/components/controlPanel/ScenarioControlPanel.tsx
+++ b/frontend/src/components/controlPanel/ScenarioControlPanel.tsx
@@ -18,9 +18,7 @@ export function ScenarioControlPanel({
   showAzimuth,
   toggleAzimuth,
   onStopSimulation,
-  simulationRunning,
-  onToggleScenario,
-  isLogging
+  simulationRunning
 }: ScenarioControlPanelProps) {
   return (
     <div className="navbar">
@@ -44,12 +42,6 @@ export function ScenarioControlPanel({
 
         <button className="azimuth-button" onClick={toggleAzimuth}>
           {showAzimuth ? 'Hide Azimuth' : 'Show Azimuth'}
-        </button>
-        <button
-          onClick={onToggleScenario}
-          className={isLogging ? 'stop-button' : 'start-button'}
-        >
-          {isLogging ? 'Stop Scenario' : 'Start Scenario'}
         </button>
         <button
           onClick={onStopSimulation}

--- a/frontend/src/constants/scenarioOptions.ts
+++ b/frontend/src/constants/scenarioOptions.ts
@@ -1,14 +1,14 @@
-export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'depart-harbor' | 'unknown-vibration' | 'narrow-fjord'
-/*| 'advice-detent-1' | 'advice-detent-2' | 'advice-detent-3' | 'caution-detent-1' | 
+export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'depart-harbor'  | 'narrow-fjord'
+/* | 'unknown-vibration' | 'advice-detent-1' | 'advice-detent-2' | 'advice-detent-3' | 'caution-detent-1' | 
 'caution-detent-2' | 'caution-detent-3' */
 
 export const scenarioOptions: Record<ScenarioKey, string> = {
     'maintain-speed': 'Maintain Speed',
     'turn-around': 'Turn Around',
     'depart-harbor': 'Depart Harbor',
-    'unknown-vibration': 'Unknown Vibration',
     'narrow-fjord': 'Narrow Fjord'
     /*
+    'unknown-vibration': 'Unknown Vibration',
     'advice-detent-1': 'Advice Detent 1',
     'advice-detent-2': 'Advice Detent 2',
     'advice-detent-3': 'Advice Detent 3',

--- a/frontend/src/constants/scenarioOptions.ts
+++ b/frontend/src/constants/scenarioOptions.ts
@@ -1,18 +1,19 @@
-export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'depart-harbor' 
-| 'advice-detent-1' | 'advice-detent-2' | 'advice-detent-3' | 'caution-detent-1' | 
-'caution-detent-2' | 'caution-detent-3' 
+export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'depart-harbor' | 'unknown-vibration' | 'narrow-fjord'
+/*| 'advice-detent-1' | 'advice-detent-2' | 'advice-detent-3' | 'caution-detent-1' | 
+'caution-detent-2' | 'caution-detent-3' */
 
 export const scenarioOptions: Record<ScenarioKey, string> = {
     'maintain-speed': 'Maintain Speed',
     'turn-around': 'Turn Around',
     'depart-harbor': 'Depart Harbor',
-    
-
-
+    'unknown-vibration': 'Unknown Vibration',
+    'narrow-fjord': 'Narrow Fjord'
+    /*
     'advice-detent-1': 'Advice Detent 1',
     'advice-detent-2': 'Advice Detent 2',
     'advice-detent-3': 'Advice Detent 3',
     'caution-detent-1': 'Caution Detent 1',
     'caution-detent-2': 'Caution Detent 2',
     'caution-detent-3': 'Caution Detent 3'
+    */
   }

--- a/frontend/src/constants/scenarioOptions.ts
+++ b/frontend/src/constants/scenarioOptions.ts
@@ -1,12 +1,14 @@
-export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'navigate-buoys' | 'depart-harbor' 
+export type ScenarioKey = 'maintain-speed' | 'turn-around' | 'depart-harbor' 
 | 'advice-detent-1' | 'advice-detent-2' | 'advice-detent-3' | 'caution-detent-1' | 
 'caution-detent-2' | 'caution-detent-3' 
 
 export const scenarioOptions: Record<ScenarioKey, string> = {
     'maintain-speed': 'Maintain Speed',
     'turn-around': 'Turn Around',
-    'navigate-buoys': 'Navigate Buoys',
     'depart-harbor': 'Depart Harbor',
+    
+
+
     'advice-detent-1': 'Advice Detent 1',
     'advice-detent-2': 'Advice Detent 2',
     'advice-detent-3': 'Advice Detent 3',

--- a/frontend/src/hooks/useBoundaryFeedback.ts
+++ b/frontend/src/hooks/useBoundaryFeedback.ts
@@ -3,15 +3,18 @@ import { BoundaryConfig } from '../types/BoundaryConfig'
 
 
 interface UseBoundaryFeedbackProps {
+  enabled: boolean
   config: BoundaryConfig[]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sendToBackend: (message: any) => void
 }
 
-export function useBoundaryFeedback({ config, sendToBackend }: UseBoundaryFeedbackProps) {
+export function useBoundaryFeedback({ enabled, config, sendToBackend }: UseBoundaryFeedbackProps) {
     const sentRef = useRef<string>('')
 
   useEffect(() => {
+    if (!enabled) return
+
     const serialized = JSON.stringify(config)
     if (sentRef.current === serialized) return // skip repeat sends of the same boundaries
 
@@ -31,5 +34,5 @@ export function useBoundaryFeedback({ config, sendToBackend }: UseBoundaryFeedba
     })
     sentRef.current = serialized
 
-  }, [config, sendToBackend])
+  }, [config, enabled, sendToBackend])
 }

--- a/frontend/src/hooks/useDetentFeedback.ts
+++ b/frontend/src/hooks/useDetentFeedback.ts
@@ -3,8 +3,6 @@ import { AngleAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instr
 import { LinearAdvice } from '@oicl/openbridge-webcomponents/src/navigation-instruments/thruster/advice'
 import { AlertConfig } from '../types/AlertConfig'
 
-
-
 type UseDetentFeedbackProps = {
   thrust: number
   angle: number

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -276,7 +276,31 @@ export function Dashboard() {
     // Redirect back to startup page
     void navigate('/')
   }
+  
+  const handleScenarioChange = (newScenario: ScenarioKey) => {
+    if (newScenario !== selectedScenario) {
+      // If logging is active, stop it and save current data
+      if (isLogging) {
+        stopLogging() // you can expand this to also export/save if needed
+      }
 
+      setSelectedScenario(newScenario)
+
+      // Start new logging session if simulation is running
+      if (simulationRunning) {
+        scenarioId.current = new Date().toISOString()
+        setLogData([])
+        setIsLogging(true)
+        console.log(`Started logging for scenario ${newScenario}`)
+      } else {
+        console.warn(
+          'Scenario changed but simulation is not running. Logging not started.'
+        )
+      }
+    }
+  }
+
+  /*
   const startLogging = () => {
     if (!simulationRunning) {
       console.warn('Cannot start logging when simulation is not running.')
@@ -287,6 +311,7 @@ export function Dashboard() {
     setIsLogging(true)
     console.log(`Started logging scenario ${scenarioCount.current}`)
   }
+    */
 
   const stopLogging = () => {
     if (logData.length > 0 && scenarioId.current) {
@@ -300,14 +325,14 @@ export function Dashboard() {
 
   const toggleScenario = () => {
     if (isLogging) stopLogging()
-    else startLogging()
+    else handleScenarioChange(selectedScenario)
   }
 
   return (
     <div>
       <ScenarioControlPanel
         selectedScenario={selectedScenario}
-        onScenarioChange={setSelectedScenario}
+        onScenarioChange={handleScenarioChange}
         showAzimuth={showAzimuth}
         toggleAzimuth={() => setShowAzimuth((prev) => !prev)}
         onStopSimulation={stopSimulation}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -120,8 +120,9 @@ export function Dashboard() {
       state?.alertConfig ||
       ({
         vibrationEnter: 2,
-        enableVibration: true,
+        enableVibration: false,
         enableDetents: false,
+        enableBoundaries: false,
         adviceHighResistance: true,
         regularHighResistance: true
       } as AlertConfig),
@@ -239,6 +240,7 @@ export function Dashboard() {
   })
 
   useBoundaryFeedback({
+    enabled: alertConfig.enableBoundaries,
     config: boundaryConfig,
     sendToBackend
   })
@@ -276,7 +278,7 @@ export function Dashboard() {
     // Redirect back to startup page
     void navigate('/')
   }
-  
+
   const handleScenarioChange = (newScenario: ScenarioKey) => {
     if (newScenario !== selectedScenario) {
       // If logging is active, stop it and save current data

--- a/frontend/src/pages/Startup.tsx
+++ b/frontend/src/pages/Startup.tsx
@@ -29,7 +29,8 @@ export function Startup() {
     adviceHighResistance: true,
     regularHighResistance: false,
     vibrationStrengthThruster: 1,
-    vibrationStrengthAngle: 1
+    vibrationStrengthAngle: 1,
+    enableBoundaries: true
   })
 
   const initialSimData: SimulatorData = {
@@ -42,8 +43,8 @@ export function Startup() {
     consumptionRate: 0,
     consumedTotal: 0,
     checkpoints: 3,
-    power: 0, // Power of azimuth thruster
-    angle: 0 // Angle of azimuth thruster
+    thrust: 0,
+    angle: 0
   }
   // Create WebSocket connection to the simulator
   const { sendMessage: sendToSimulator } = UseSimulatorWebSocket(
@@ -274,28 +275,6 @@ export function Startup() {
             </div>
           ))}
 
-          {/* Checkbox options */}
-          <div className="label-container">
-            <div className="label-wrapper">
-              <span
-                className="info-icon"
-                data-tooltip="Enable vibration feedback"
-              >
-                ℹ
-              </span>
-              <label>Enable Vibration</label>
-            </div>
-            <input
-              type="checkbox"
-              checked={alertConfig.enableVibration}
-              onChange={() =>
-                setAlertConfig((prev) => ({
-                  ...prev,
-                  enableVibration: !prev.enableVibration
-                }))
-              }
-            />
-          </div>
           {alertConfig.enableVibration && (
             <>
               <div className="label-container">
@@ -347,7 +326,28 @@ export function Startup() {
               </div>
             </>
           )}
-
+          {/* Checkbox options */}
+          <div className="label-container">
+            <div className="label-wrapper">
+              <span
+                className="info-icon"
+                data-tooltip="Enable vibration feedback"
+              >
+                ℹ
+              </span>
+              <label>Enable Vibration</label>
+            </div>
+            <input
+              type="checkbox"
+              checked={alertConfig.enableVibration}
+              onChange={() =>
+                setAlertConfig((prev) => ({
+                  ...prev,
+                  enableVibration: !prev.enableVibration
+                }))
+              }
+            />
+          </div>
           <div className="label-container">
             <div className="label-wrapper">
               <span className="info-icon" data-tooltip="Enable detent feedback">
@@ -366,6 +366,28 @@ export function Startup() {
               }
             />
           </div>
+          <div className="label-container">
+            <div className="label-wrapper">
+              <span
+                className="info-icon"
+                data-tooltip="Enable physical haptic boundary walls in the controller"
+              >
+                ℹ
+              </span>
+              <label>Enable Boundaries</label>
+            </div>
+            <input
+              type="checkbox"
+              checked={alertConfig.enableBoundaries}
+              onChange={() =>
+                setAlertConfig((prev) => ({
+                  ...prev,
+                  enableBoundaries: !prev.enableBoundaries
+                }))
+              }
+            />
+          </div>
+
           {/* Toggle for High Resistance Inside Advice Zones */}
           <div className="label-container">
             <div className="label-wrapper">

--- a/frontend/src/styles/navBar.css
+++ b/frontend/src/styles/navBar.css
@@ -20,7 +20,7 @@
   .navbar-right {
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: 24px;
   }
   
   .navbar label {

--- a/frontend/src/types/AlertConfig.ts
+++ b/frontend/src/types/AlertConfig.ts
@@ -6,4 +6,5 @@ export type AlertConfig = {
   regularHighResistance: boolean
   vibrationStrengthThruster: number
   vibrationStrengthAngle: number
+  enableBoundaries: boolean
 }

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -71,9 +71,11 @@ export const scenarioAdviceMap: Record<
     angleDetentStrength: 1,
     thrustDetentStrength: 1,
     angleAdvices: [
-      { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true }
+      { minAngle: 1, maxAngle: 40, type: AdviceType.caution, hinted: true }
     ],
-    thrustAdvices: [{ min: 30, max: 80, type: AdviceType.advice, hinted: true }]
+    thrustAdvices: [
+      { min: 30, max: 80, type: AdviceType.caution, hinted: true }
+    ]
   },
   'narrow-fjord': {
     angleDetentStrength: 1,

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -36,8 +36,8 @@ export const scenarioAdviceMap: Record<
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
-      { minAngle: 70, maxAngle: 180, type: AdviceType.caution, hinted: true },
-      { minAngle: -180, maxAngle: -70, type: AdviceType.caution, hinted: true }
+      { minAngle: 110, maxAngle: 250, type: AdviceType.caution, hinted: true }
+      //{ minAngle: 181, maxAngle: 250, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [{ min: 10, max: 30, type: AdviceType.advice, hinted: true }]
   },
@@ -48,8 +48,7 @@ export const scenarioAdviceMap: Record<
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
-      { minAngle: 70, maxAngle: 180, type: AdviceType.caution, hinted: true },
-      { minAngle: -180, maxAngle: -70, type: AdviceType.caution, hinted: true }
+      { minAngle: 70, maxAngle: 250, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [
       { min: 20, max: 60, type: AdviceType.advice, hinted: true },
@@ -61,15 +60,15 @@ export const scenarioAdviceMap: Record<
   // Due to the speed limit, boundaries should be set at 4 knots
   'depart-harbor': {
     angleDetentStrength: 1,
-    thrustDetentStrength: 1,
+    thrustDetentStrength: 2,
     angleAdvices: [
       { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
       { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
       { minAngle: 60, maxAngle: 240, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [
-      { min: 0, max: 40, type: AdviceType.advice, hinted: true },
-      { min: 50, max: 100, type: AdviceType.caution, hinted: true }
+      { min: 10, max: 40, type: AdviceType.advice, hinted: true },
+      { min: 45, max: 100, type: AdviceType.caution, hinted: true }
     ],
     boundaries: [
       {
@@ -77,7 +76,7 @@ export const scenarioAdviceMap: Record<
         boundary: 3,
         type: 'thrust',
         lower: 1,
-        upper: 41
+        upper: 45
       }
     ]
   },

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -67,7 +67,7 @@ export const scenarioAdviceMap: Record<
       }
     ]
   },
-  'advice-detent-1': {
+  'unknown-vibration': {
     angleDetentStrength: 1,
     thrustDetentStrength: 1,
     angleAdvices: [
@@ -75,14 +75,26 @@ export const scenarioAdviceMap: Record<
     ],
     thrustAdvices: [{ min: 30, max: 80, type: AdviceType.advice, hinted: true }]
   },
-  'advice-detent-2': {
-    angleDetentStrength: 2,
-    thrustDetentStrength: 2,
+  'narrow-fjord': {
+    angleDetentStrength: 1,
+    thrustDetentStrength: 1,
     angleAdvices: [
-      { minAngle: 30, maxAngle: 50, type: AdviceType.advice, hinted: true }
+      { minAngle: 350, maxAngle: 10, type: AdviceType.advice, hinted: true }
     ],
-    thrustAdvices: [{ min: 10, max: 40, type: AdviceType.advice, hinted: true }]
-  },
+    thrustAdvices: [
+      { min: 10, max: 40, type: AdviceType.advice, hinted: true }
+    ],
+    boundaries: [
+      {
+        enabled: true,
+        boundary: 1,
+        type: 'angle',
+        lower: 350,
+        upper: 10
+      }
+    ]
+  }
+  /*
   'advice-detent-3': {
     angleDetentStrength: 3,
     thrustDetentStrength: 3,
@@ -121,5 +133,5 @@ export const scenarioAdviceMap: Record<
     thrustAdvices: [
       { min: 50, max: 100, type: AdviceType.caution, hinted: true }
     ]
-  }
+  }*/
 }

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -41,20 +41,7 @@ export const scenarioAdviceMap: Record<
     ],
     thrustAdvices: [{ min: 10, max: 30, type: AdviceType.advice, hinted: true }]
   },
-  // The operator should aim to hit the buoys
-  'navigate-buoys': {
-    angleDetentStrength: 1,
-    thrustDetentStrength: 1,
-    angleAdvices: [
-      { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
-      { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
-      { minAngle: 70, maxAngle: 250, type: AdviceType.caution, hinted: true }
-    ],
-    thrustAdvices: [
-      { min: 20, max: 60, type: AdviceType.advice, hinted: true },
-      { min: 80, max: 100, type: AdviceType.caution, hinted: true }
-    ]
-  },
+
   // The operator shuold leave the harbor. The harbor has a speed limit of 4 knots
   // After leaving the harbor, they should aim for 8 knots
   // Due to the speed limit, boundaries should be set at 4 knots

--- a/frontend/src/utils/ScenarioMap.tsx
+++ b/frontend/src/utils/ScenarioMap.tsx
@@ -34,10 +34,9 @@ export const scenarioAdviceMap: Record<
     angleDetentStrength: 1,
     thrustDetentStrength: 1,
     angleAdvices: [
-      { minAngle: 320, maxAngle: 359, type: AdviceType.advice, hinted: true },
-      { minAngle: 1, maxAngle: 40, type: AdviceType.advice, hinted: true },
-      { minAngle: 110, maxAngle: 250, type: AdviceType.caution, hinted: true }
-      //{ minAngle: 181, maxAngle: 250, type: AdviceType.caution, hinted: true }
+      { minAngle: 345, maxAngle: 359, type: AdviceType.advice, hinted: true },
+      { minAngle: 1, maxAngle: 15, type: AdviceType.advice, hinted: true },
+      { minAngle: 50, maxAngle: 200, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [{ min: 10, max: 30, type: AdviceType.advice, hinted: true }]
   },
@@ -54,8 +53,8 @@ export const scenarioAdviceMap: Record<
       { minAngle: 60, maxAngle: 240, type: AdviceType.caution, hinted: true }
     ],
     thrustAdvices: [
-      { min: 10, max: 40, type: AdviceType.advice, hinted: true },
-      { min: 45, max: 100, type: AdviceType.caution, hinted: true }
+      { min: 20, max: 50, type: AdviceType.advice, hinted: true },
+      { min: 50, max: 100, type: AdviceType.caution, hinted: true }
     ],
     boundaries: [
       {
@@ -67,6 +66,7 @@ export const scenarioAdviceMap: Record<
       }
     ]
   },
+  /*
   'unknown-vibration': {
     angleDetentStrength: 1,
     thrustDetentStrength: 1,
@@ -77,6 +77,7 @@ export const scenarioAdviceMap: Record<
       { min: 30, max: 80, type: AdviceType.caution, hinted: true }
     ]
   },
+  */
   'narrow-fjord': {
     angleDetentStrength: 1,
     thrustDetentStrength: 1,


### PR DESCRIPTION
This PR fully implements the following eco-feedback scenarios for testing haptic feedback (vibration, detents, and boundaries):

**Maintain Speed**
(Vibration + Detent)
The eco-feedback system advises maintaining 4 knots to optimize fuel efficiency.

**Off-Course Correction**
(Vibration + Detent + Boundary)
The vessel is off-course; user is prompted to turn right to re-enter the designated path.

**Departing Harbor**
(Vibration + Detent + Boundary)
Speed limits dynamically change from 5 to 8 knots as user leaves the harbor.

**Unknown Vibration - ended up removing this one though**
(Vibration only)
User experiences a sudden vibration without visual cue; used to gauge intuitive interpretation of haptic feedback.

**Navigating Fjord**
(Boundary only)
Friction is applied when attempting to oversteer. Used to simulate tight navigation conditions.

**In addition, these bugfixes and improvements were made:**
**Boundary logging updated:**
Boundary events now log both entry and exit, ensuring complete tracking of interactions.

**Boundary zone logic:**
Boundaries are now only applied to thrust, not angle — as originally intended. Boundaries on angle were a bug caused by stale configs not being cleared correctly.

**Boundaries are gated by startup config:**
Boundaries are only sent to backend if enableBoundaries is checked in the startup UI. Mirrors existing behavior for vibrations and detents.

**Removed redundant start scenario button:**
Logging now begins automatically when a new scenario is selected.

**Automatic CSV export:**
A CSV is saved every time the scenario changes (if logging is active), and again when the simulation is stopped.

**Startup checkbox added for boundaries:**
Users can now explicitly disable/enable boundary feedback alongside vibration and detents.

**"Unknown Vibration" scenario adjusted - and then later removed**
Features a vibration-only alert as designed (previously missing vibration). Was remvoed towards the end, because of the savings it would make in time for each experiment.